### PR TITLE
ci: add backend validation workflow

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,73 @@
+name: Backend CI
+
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend.yml"
+
+jobs:
+  backend:
+    name: Backend checks (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x, 20.x]
+
+    defaults:
+      run:
+        working-directory: backend
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: novasupport_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d novasupport_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/novasupport_test
+      DIRECT_URL: postgresql://postgres:postgres@127.0.0.1:5432/novasupport_test
+      NODE_ENV: test
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install backend dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run db:generate
+
+      - name: Apply database migrations
+        run: npm run db:migrate:deploy
+
+      - name: Run backend tests
+        run: npm run test
+
+      - name: Build backend
+        run: npm run build

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,8 +6,11 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "tsx src/index.test.ts",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
     "db:setup": "npm run db:generate && npm run db:migrate && npm run db:seed",
     "db:reset": "prisma migrate reset --force",
@@ -27,9 +30,6 @@
     "prisma": "^6.5.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"
-  },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
   }
 }
 

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,0 +1,13 @@
+import "dotenv/config";
+import { defineConfig, env } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+    seed: "tsx prisma/seed.ts"
+  },
+  datasource: {
+    url: env("DATABASE_URL")
+  }
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,68 @@
+import cors from "cors";
+import express from "express";
+import { z } from "zod";
+import { prisma } from "./db.js";
+
+export function createApp() {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+
+  app.get("/health", (_req, res) => {
+    res.json({
+      ok: true,
+      service: "NovaSupport backend",
+      network: "Stellar Testnet"
+    });
+  });
+
+  app.get("/profiles/:username", async (req, res) => {
+    const profile = await prisma.profile.findUnique({
+      where: { username: req.params.username },
+      include: {
+        acceptedAssets: true
+      }
+    });
+
+    if (!profile) {
+      res.status(404).json({ error: "Profile not found" });
+      return;
+    }
+
+    res.json(profile);
+  });
+
+  const supportPayloadSchema = z.object({
+    txHash: z.string().min(3),
+    amount: z.string().min(1),
+    assetCode: z.string().min(1),
+    assetIssuer: z.string().optional().nullable(),
+    status: z.string().default("pending"),
+    message: z.string().max(280).optional().nullable(),
+    stellarNetwork: z.string().default("TESTNET"),
+    supporterAddress: z.string().optional().nullable(),
+    recipientAddress: z.string().min(1),
+    profileId: z.string().min(1),
+    supporterId: z.string().optional().nullable()
+  });
+
+  app.post("/support-transactions", async (req, res) => {
+    const parsed = supportPayloadSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.flatten() });
+      return;
+    }
+
+    const supportRecord = await prisma.supportTransaction.create({
+      data: parsed.data
+    });
+
+    res.status(201).json(supportRecord);
+  });
+
+  return app;
+}
+
+export const app = createApp();

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import type { AddressInfo } from "node:net";
+import { app } from "./app.js";
+import { prisma } from "./db.js";
+
+const baseUsername = "stellar-dev";
+const seedEmail = "builder@novasupport.dev";
+const walletAddress = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+let baseUrl = "";
+let profileId = "";
+let server: ReturnType<typeof app.listen>;
+
+async function seedProfile() {
+  const user = await prisma.user.upsert({
+    where: { email: seedEmail },
+    update: {},
+    create: {
+      email: seedEmail
+    }
+  });
+
+  const profile = await prisma.profile.upsert({
+    where: { username: baseUsername },
+    update: {},
+    create: {
+      username: baseUsername,
+      displayName: "Stellar Dev Collective",
+      bio: "Shipping guides, tools, and experiments that help more builders work on Stellar.",
+      walletAddress,
+      ownerId: user.id
+    }
+  });
+
+  await prisma.acceptedAsset.deleteMany({
+    where: {
+      profileId: profile.id
+    }
+  });
+
+  await prisma.acceptedAsset.createMany({
+    data: [
+      {
+        code: "XLM",
+        profileId: profile.id
+      },
+      {
+        code: "USDC",
+        issuer: "GA5ZSEJYB37Y5WZL56FWSOZ5LX5K7Q4SOX7YH3Y2AWJZQURQW6Z5YB2M",
+        profileId: profile.id
+      }
+    ],
+    skipDuplicates: true
+  });
+
+  profileId = profile.id;
+}
+
+async function startServer() {
+  await seedProfile();
+
+  server = app.listen(0);
+  await new Promise<void>((resolve) => {
+    server.once("listening", () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+}
+
+async function stopServer() {
+  if (server.listening) {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
+  await prisma.supportTransaction.deleteMany({
+    where: {
+      txHash: {
+        startsWith: "ci-test-"
+      }
+    }
+  });
+
+  await prisma.$disconnect();
+}
+
+async function runTest(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    console.log(`PASS ${name}`);
+  } catch (error) {
+    console.error(`FAIL ${name}`);
+    throw error;
+  }
+}
+
+async function main() {
+  await startServer();
+
+  try {
+    await runTest("returns health status", async () => {
+      const response = await fetch(`${baseUrl}/health`);
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(await response.json(), {
+        ok: true,
+        service: "NovaSupport backend",
+        network: "Stellar Testnet"
+      });
+    });
+
+    await runTest("returns a seeded profile with accepted assets", async () => {
+      const response = await fetch(`${baseUrl}/profiles/${baseUsername}`);
+
+      assert.equal(response.status, 200);
+
+      const profile = await response.json();
+      assert.equal(profile.username, baseUsername);
+      assert.equal(profile.walletAddress, walletAddress);
+      assert.equal(profile.acceptedAssets.length, 2);
+    });
+
+    await runTest("creates a support transaction when the payload is valid", async () => {
+      const response = await fetch(`${baseUrl}/support-transactions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          txHash: `ci-test-${randomUUID()}`,
+          amount: "5.0000000",
+          assetCode: "XLM",
+          recipientAddress: walletAddress,
+          profileId,
+          message: "Thanks for maintaining NovaSupport."
+        })
+      });
+
+      assert.equal(response.status, 201);
+
+      const transaction = await response.json();
+      assert.equal(transaction.assetCode, "XLM");
+      assert.equal(transaction.status, "pending");
+      assert.equal(transaction.profileId, profileId);
+    });
+
+    await runTest("returns a validation error for incomplete support payloads", async () => {
+      const response = await fetch(`${baseUrl}/support-transactions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          txHash: "bad"
+        })
+      });
+
+      assert.equal(response.status, 400);
+
+      const body = await response.json();
+      assert.ok(body.error.fieldErrors.amount);
+      assert.ok(body.error.fieldErrors.assetCode);
+      assert.ok(body.error.fieldErrors.recipientAddress);
+      assert.ok(body.error.fieldErrors.profileId);
+    });
+  } finally {
+    await stopServer();
+  }
+}
+
+main().catch((error) => {
+  console.error("Backend tests failed.");
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,67 +1,7 @@
 import "dotenv/config";
-import cors from "cors";
-import express from "express";
-import { z } from "zod";
-import { prisma } from "./db.js";
+import { app } from "./app.js";
 
-const app = express();
 const port = Number(process.env.PORT ?? 4000);
-
-app.use(cors());
-app.use(express.json());
-
-app.get("/health", (_req, res) => {
-  res.json({
-    ok: true,
-    service: "NovaSupport backend",
-    network: "Stellar Testnet"
-  });
-});
-
-app.get("/profiles/:username", async (req, res) => {
-  const profile = await prisma.profile.findUnique({
-    where: { username: req.params.username },
-    include: {
-      acceptedAssets: true
-    }
-  });
-
-  if (!profile) {
-    res.status(404).json({ error: "Profile not found" });
-    return;
-  }
-
-  res.json(profile);
-});
-
-const supportPayloadSchema = z.object({
-  txHash: z.string().min(3),
-  amount: z.string().min(1),
-  assetCode: z.string().min(1),
-  assetIssuer: z.string().optional().nullable(),
-  status: z.string().default("pending"),
-  message: z.string().max(280).optional().nullable(),
-  stellarNetwork: z.string().default("TESTNET"),
-  supporterAddress: z.string().optional().nullable(),
-  recipientAddress: z.string().min(1),
-  profileId: z.string().min(1),
-  supporterId: z.string().optional().nullable()
-});
-
-app.post("/support-transactions", async (req, res) => {
-  const parsed = supportPayloadSchema.safeParse(req.body);
-
-  if (!parsed.success) {
-    res.status(400).json({ error: parsed.error.flatten() });
-    return;
-  }
-
-  const supportRecord = await prisma.supportTransaction.create({
-    data: parsed.data
-  });
-
-  res.status(201).json(supportRecord);
-});
 
 app.listen(port, () => {
   console.log(`NovaSupport backend listening on http://localhost:${port}`);


### PR DESCRIPTION
Closes #2

---

Add backend CI validation with PostgreSQL-backed checks for pull requests and pushes to main.

Changes
add .github/workflows/backend.yml for backend-only CI
run checks on PRs touching backend/** and on pushes to main
start a PostgreSQL service in GitHub Actions
generate Prisma client and apply migrations before tests
add backend test and build scripts
add database-backed backend integration tests
move Prisma CLI config into prisma.config.ts
Validation
npm run build
npm run db:generate
CI runs npm run test and npm run build on Node 18.x and 20.x