### PR TITLE
ci: add contract validation workflow

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,0 +1,46 @@
+name: Contract CI
+
+on:
+  pull_request:
+    paths:
+      - "contract/**"
+      - ".github/workflows/contract.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "contract/**"
+      - ".github/workflows/contract.yml"
+
+jobs:
+  contract:
+    name: Contract checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: contract
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust with WASM target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contract
+
+      - name: Build contract for native target
+        run: cargo build --release
+
+      - name: Build contract for WASM target
+        run: cargo build --target wasm32-unknown-unknown --release
+
+      - name: Run contract tests
+        run: cargo test


### PR DESCRIPTION
Closes #3

---

Add GitHub Actions validation for Soroban contract changes.

Changes
add .github/workflows/contract.yml
run on PRs touching contract/** and on pushes to main
install stable Rust and the wasm32-unknown-unknown target
cache Cargo dependencies for faster runs
build the contract for native and WASM targets
run all contract tests with cargo test