### PR TITLE
build: add npm run build script for TypeScript compilation

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,8 @@
+# Compiled TypeScript output
+dist/
+
+# Environment variables
+.env
+
+# Dependencies
+node_modules/


### PR DESCRIPTION
## Summary

Closes #30

Completes the TypeScript build pipeline for the backend so contributors and CI can compile the project cleanly with `npm run build`.

---

## What was already in place

After reading the codebase, two of the three required pieces were already present:

| File | Status |
|------|--------|
| `backend/package.json` | ✅ Already has `"build": "tsc -p tsconfig.json"` |
| `backend/tsconfig.json` | ✅ Already has `"outDir": "dist"` |
| `backend/.gitignore` | ❌ Missing — created in this PR |

---

## What this PR adds

**`backend/.gitignore`** (new file):
```
# Compiled TypeScript output
dist/

# Environment variables
.env

# Dependencies
node_modules/
```

The root `.gitignore` already excludes `dist/` at the repo level, but a package-level `.gitignore` inside `backend/` makes the intent explicit and ensures the exclusion is enforced regardless of where `git` is invoked from.

---

## Acceptance Criteria

- [x] `npm run build` in `backend/` compiles TypeScript to `dist/` without errors
- [x] `dist/` is listed in `backend/.gitignore`
- [x] No TypeScript errors on current `main`