### PR TITLE
docs: add CLI and JavaScript invocation examples to contract README

### DIFF
--- a/contract/README.md
+++ b/contract/README.md
@@ -27,3 +27,103 @@ cd contract
 cargo test
 ```
 
+## Contract Invocation
+
+After deploying the contract to Testnet, you can invoke the `support()` function using either the Stellar CLI or JavaScript.
+
+### CLI Example
+
+Use the Stellar CLI to call the contract directly:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  --source mykey \
+  -- support \
+  --supporter <SUPPORTER_ADDRESS> \
+  --recipient <RECIPIENT_ADDRESS> \
+  --amount 10000000 \
+  --asset_code XLM \
+  --message "Great work!"
+```
+
+**Note:** The `amount` is in stroops (1 XLM = 10,000,000 stroops).
+
+### JavaScript Example
+
+Use `@stellar/stellar-sdk` to invoke the contract from JavaScript:
+
+```javascript
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Address,
+  nativeToScVal,
+} from "@stellar/stellar-sdk";
+
+const server = new SorobanRpc.Server("https://soroban-testnet.stellar.org");
+const contract = new Contract("<CONTRACT_ID>");
+
+// Get the supporter account
+const account = await server.getAccount("<SUPPORTER_ADDRESS>");
+
+// Build the transaction
+const tx = new TransactionBuilder(account, {
+  fee: BASE_FEE,
+  networkPassphrase: Networks.TESTNET,
+})
+  .addOperation(
+    contract.call(
+      "support",
+      nativeToScVal(Address.fromString("<SUPPORTER_ADDRESS>"), {
+        type: "address",
+      }),
+      nativeToScVal(Address.fromString("<RECIPIENT_ADDRESS>"), {
+        type: "address",
+      }),
+      nativeToScVal(10000000, { type: "i128" }), // amount in stroops
+      nativeToScVal("XLM", { type: "string" }),
+      nativeToScVal("Great work!", { type: "string" }),
+    ),
+  )
+  .setTimeout(30)
+  .build();
+
+// Prepare the transaction
+const preparedTx = await server.prepareTransaction(tx);
+
+// Sign with Freighter or a keypair
+// preparedTx.sign(keypair);
+
+// Submit the transaction
+// const result = await server.sendTransaction(preparedTx);
+```
+
+**Note:** Remember to sign the transaction with the supporter's keypair or using a wallet like Freighter before submitting.
+
+### Query Functions
+
+You can also query the contract state:
+
+**Get global support count:**
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- support_count
+```
+
+**Get recipient-specific support count:**
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- recipient_count \
+  --recipient <RECIPIENT_ADDRESS>
+```


### PR DESCRIPTION
This PR adds comprehensive contract invocation examples to help contributors and integrators call the support contract after deployment.

## Changes
- Added **Contract Invocation** section to `contract/README.md`
- Included CLI example using Stellar CLI with all required parameters
- Included JavaScript example using `@stellar/stellar-sdk` with proper parameter encoding
- Added query function examples for `support_count()` and `recipient_count()`
- Documented amount units (stroops vs XLM) with clear notes

## Examples Included

### CLI Example
- Shows how to invoke `support()` function with all parameters
- Includes note about stroops (1 XLM = 10,000,000 stroops)

### JavaScript Example
- Demonstrates SorobanRpc server setup
- Shows Contract.call pattern with proper parameter encoding using `nativeToScVal`
- Includes transaction building, preparation, and signing flow
- Clear comments about signing with Freighter or keypair

### Query Examples
- `support_count()` - Get global support count
- `recipient_count()` - Get per-recipient support count

## Benefits
- Developers can quickly understand how to interact with the deployed contract
- Copy-paste ready examples for both CLI and JavaScript
- Clear documentation of parameter types and units
- Reduces integration friction for contributors

Closes #45