### PR TITLE
docs: add missing frontend env vars

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,4 +2,6 @@ NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 NEXT_PUBLIC_STELLAR_NETWORK=TESTNET
 NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 NEXT_PUBLIC_SUPABASE_URL=https://crnsvgljoopphjnmcawu.supabase.co
+NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
+NEXT_PUBLIC_CONTRACT_ID=
 


### PR DESCRIPTION
Closes #113

## Summary
- add `NEXT_PUBLIC_API_BASE_URL` to `frontend/.env.example`
- add `NEXT_PUBLIC_CONTRACT_ID` as a placeholder entry in `frontend/.env.example`
- keep the change docs-only with no frontend or backend code changes

## Validation
- checked `frontend/src/lib/config.ts` and searched `process.env` usage across the frontend
- ran `npm run build` in `frontend/`

## Notes
- `NEXT_PUBLIC_API_BASE_URL` is currently referenced in the frontend source
- `NEXT_PUBLIC_CONTRACT_ID` is not currently referenced in the checked-in frontend tree, but it was added here to match the issue's requested env example and avoid missing-doc drift if the Stellar integration expects it next
