### PR TITLE
feat: add connect wallet CTA to profile page when wallet not connected

### DIFF
--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -1,10 +1,27 @@
+"use client";
+
+import { useState } from "react";
 import { getNetworkLabel, stellarConfig } from "@/lib/stellar";
+import { WalletConnect } from "./wallet-connect";
 
 type SupportPanelProps = {
   walletAddress: string;
 };
 
 export function SupportPanel({ walletAddress }: SupportPanelProps) {
+  const [visitorAddress, setVisitorAddress] = useState<string | null>(null);
+
+  if (!visitorAddress) {
+    return (
+      <section className="rounded-[2rem] border border-gold/25 bg-gold/10 p-7 text-center">
+        <p className="mb-4 text-sm text-sky/85">
+          Connect your Freighter wallet to support this creator.
+        </p>
+        <WalletConnect onConnect={setVisitorAddress} />
+      </section>
+    );
+  }
+
   return (
     <section className="rounded-[2rem] border border-gold/25 bg-gold/10 p-7">
       <p className="text-xs uppercase tracking-[0.25em] text-gold">Support intent</p>
@@ -31,4 +48,3 @@ export function SupportPanel({ walletAddress }: SupportPanelProps) {
     </section>
   );
 }
-

--- a/frontend/src/components/wallet-connect.tsx
+++ b/frontend/src/components/wallet-connect.tsx
@@ -7,7 +7,11 @@ function truncateAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(-6)}`;
 }
 
-export function WalletConnect() {
+type WalletConnectProps = {
+  onConnect?: (address: string) => void;
+};
+
+export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
   const [address, setAddress] = useState<string | null>(null);
   const [status, setStatus] = useState("Connect Freighter to preview Stellar Testnet support.");
   const [errorType, setErrorType] = useState<"not_installed" | "denied" | "wrong_network" | null>(null);
@@ -46,6 +50,7 @@ export function WalletConnect() {
 
       setAddress(result.address);
       setStatus("Freighter connected on Stellar Testnet.");
+      onConnect?.(result.address);
     } catch (error) {
       setStatus(
         error instanceof Error


### PR DESCRIPTION
Added optional onConnect?: (address: string) => void prop
Calls it after a successful wallet connection

Added "use client" directive
Tracks visitor's wallet state with useState
When not connected: renders a CTA message + <WalletConnect onConnect={setVisitorAddress} />
When connected: renders the existing support info UI (creator's wallet address is still shown as the recipient)

closes #50 