### PR TITLE
feat: webhook delivery, asset breakdown chart, and profile QR code

### DIFF
--- a/backend/prisma/migrations/20260424000000_add_webhooks/migration.sql
+++ b/backend/prisma/migrations/20260424000000_add_webhooks/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "Webhook" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "profileId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Webhook_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Webhook_profileId_idx" ON "Webhook"("profileId");
+
+-- AddForeignKey
+ALTER TABLE "Webhook" ADD CONSTRAINT "Webhook_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Profile {
   acceptedAssets      AcceptedAsset[]
   supportTransactions SupportTransaction[]
   milestones          Milestone[]
+  webhooks            Webhook[]
 }
 
 model AcceptedAsset {
@@ -83,6 +84,19 @@ model Milestone {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
   profile       Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
+
+  @@index([profileId])
+}
+
+model Webhook {
+  id        String   @id @default(cuid())
+  url       String
+  secret    String
+  active    Boolean  @default(true)
+  profileId String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  profile   Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 
   @@index([profileId])
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -21,6 +21,7 @@ import {
 import multer from "multer";
 import { createClient } from "@supabase/supabase-js";
 import { sendSupportReceivedEmail } from "./services/email.js";
+import { createHmac } from "crypto";
 
 // Extend Express Request to include auth context
 declare global {
@@ -1265,6 +1266,58 @@ export function createApp(customLogger?: Logger) {
         }
       })();
 
+      // Deliver webhooks (async, fire-and-forget)
+      (async () => {
+        try {
+          const webhooks = await prisma.webhook.findMany({
+            where: { profileId: supportRecord.profileId, active: true },
+            include: { profile: { select: { username: true } } },
+          });
+
+          for (const webhook of webhooks) {
+            const payload = JSON.stringify({
+              event: "support.received",
+              txHash: supportRecord.txHash,
+              amount: supportRecord.amount.toString(),
+              assetCode: supportRecord.assetCode,
+              message: supportRecord.message ?? null,
+              profileUsername: webhook.profile.username,
+              createdAt: supportRecord.createdAt.toISOString(),
+            });
+
+            const signature = createHmac("sha256", webhook.secret)
+              .update(payload)
+              .digest("hex");
+
+            fetch(webhook.url, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-NovaSupport-Signature": signature,
+              },
+              body: payload,
+            })
+              .then((res) => {
+                logger.info(
+                  { webhookId: webhook.id, profileId: supportRecord.profileId, status: res.status },
+                  "webhook delivered",
+                );
+              })
+              .catch((err) => {
+                logger.error(
+                  { webhookId: webhook.id, profileId: supportRecord.profileId, err },
+                  "webhook delivery failed",
+                );
+              });
+          }
+        } catch (err) {
+          logger.error(
+            { err, txHash: supportRecord.txHash },
+            "Error fetching webhooks for delivery",
+          );
+        }
+      })();
+
       req.log.info(
         { txHash: supportRecord.txHash },
         "support transaction recorded",
@@ -1794,6 +1847,33 @@ export function createApp(customLogger?: Logger) {
     const formatted = fillGaps(results as any[], period, from, to);
 
     return res.json(formatted);
+  });
+
+  app.get("/profiles/:username/analytics/assets", async (req, res) => {
+    const { username } = req.params;
+
+    const profile = await prisma.profile.findUnique({ where: { username } });
+    if (!profile) return sendError(res, 404, "Profile not found");
+
+    const transactions = await prisma.supportTransaction.findMany({
+      where: { profileId: profile.id, status: "SUCCESS" },
+      select: { assetCode: true, amount: true },
+    });
+
+    const assetMap = new Map<string, number>();
+    for (const tx of transactions) {
+      assetMap.set(tx.assetCode, (assetMap.get(tx.assetCode) ?? 0) + Number(tx.amount));
+    }
+
+    const total = Array.from(assetMap.values()).reduce((sum, v) => sum + v, 0);
+
+    const breakdown = Array.from(assetMap.entries()).map(([assetCode, amount]) => ({
+      assetCode,
+      amount: Number(amount.toFixed(7)),
+      percentage: total > 0 ? Number(((amount / total) * 100).toFixed(2)) : 0,
+    }));
+
+    return res.json({ breakdown, total: Number(total.toFixed(7)) });
   });
 
   return app;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
         "next": "14.2.35",
+        "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recharts": "^3.8.1",
@@ -7389,6 +7390,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "next": "14.2.35",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^3.8.1",

--- a/frontend/src/app/dashboard/[campaignId]/page.tsx
+++ b/frontend/src/app/dashboard/[campaignId]/page.tsx
@@ -239,11 +239,19 @@ function downloadCsv(rows: TransactionCsvRow[]): void {
   URL.revokeObjectURL(url);
 }
 
+type AssetBreakdownEntry = {
+  assetCode: string;
+  amount: number;
+  percentage: number;
+};
+
 export default function DashboardPage() {
   const { campaignId } = useParams<{ campaignId: string }>();
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [settings, setSettings] = useState<ProfileSettings | null>(null);
   const [chartData, setChartData] = useState<ChartPoint[]>([]);
+  const [assetBreakdown, setAssetBreakdown] = useState<AssetBreakdownEntry[]>([]);
+  const [assetTotal, setAssetTotal] = useState(0);
   const [selectedPeriod, setSelectedPeriod] = useState<ChartRange>("30D");
   const [chartLoading, setChartLoading] = useState(true);
   const [connectedWallet, setConnectedWallet] = useState("");
@@ -255,9 +263,10 @@ export default function DashboardPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const [analyticsRes, profileRes] = await Promise.all([
+        const [analyticsRes, profileRes, assetsRes] = await Promise.all([
           fetch(`${API_BASE_URL}/analytics/${campaignId}`),
           fetch(`${API_BASE_URL}/profiles/${campaignId}`),
+          fetch(`${API_BASE_URL}/profiles/${campaignId}/analytics/assets`),
         ]);
         if (!analyticsRes.ok) throw new Error("Failed to fetch analytics");
         if (!profileRes.ok) throw new Error("Failed to fetch profile settings");
@@ -270,6 +279,12 @@ export default function DashboardPage() {
           email: toString(profileJson.email, "") || null,
           notifyOnSupport: toBool(profileJson.notifyOnSupport, true),
         });
+
+        if (assetsRes.ok) {
+          const assetsJson = (await assetsRes.json()) as { breakdown: AssetBreakdownEntry[]; total: number };
+          setAssetBreakdown(assetsJson.breakdown ?? []);
+          setAssetTotal(assetsJson.total ?? 0);
+        }
       } catch (err: any) {
         setError(err.message);
       } finally {
@@ -536,8 +551,8 @@ export default function DashboardPage() {
             </div>
           </motion.div>
 
-          {/* Pie Chart */}
-          <motion.div 
+          {/* Asset Breakdown Chart */}
+          <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-sm shadow-black/40"
@@ -545,33 +560,56 @@ export default function DashboardPage() {
             <h3 className="mb-6 text-sm font-semibold uppercase tracking-widest text-steel">
               Asset Distribution
             </h3>
-            <div className="h-[350px] w-full">
-              <ResponsiveContainer width="100%" height="100%">
-                <PieChart>
-                  <Pie
-                    data={data.assetBreakdown}
-                    cx="50%"
-                    cy="50%"
-                    innerRadius={60}
-                    outerRadius={100}
-                    paddingAngle={5}
-                    dataKey="value"
-                  >
-                    {data.assetBreakdown.map((_entry, index) => (
-                      <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip 
-                    contentStyle={{ 
-                      backgroundColor: "#0A0A0B", 
-                      border: "1px solid rgba(255,255,255,0.1)",
-                      borderRadius: "12px"
-                    }}
-                  />
-                  <Legend verticalAlign="bottom" height={36}/>
-                </PieChart>
-              </ResponsiveContainer>
+            <div className="h-[280px] w-full">
+              {assetBreakdown.length === 0 ? (
+                <div className="flex h-full flex-col items-center justify-center rounded-3xl border border-dashed border-white/10 bg-white/[0.02] text-center">
+                  <p className="text-lg font-semibold text-white">No earnings data yet</p>
+                  <p className="mt-2 max-w-sm text-sm text-steel">
+                    Asset breakdown will appear once you receive support.
+                  </p>
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={assetBreakdown}
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={60}
+                      outerRadius={100}
+                      paddingAngle={5}
+                      dataKey="amount"
+                      nameKey="assetCode"
+                      label={(props) => {
+                        const entry = props as unknown as AssetBreakdownEntry;
+                        return `${entry.assetCode} ${entry.percentage}%`;
+                      }}
+                      labelLine={false}
+                    >
+                      {assetBreakdown.map((_entry, index) => (
+                        <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: "#0A0A0B",
+                        border: "1px solid rgba(255,255,255,0.1)",
+                        borderRadius: "12px",
+                      }}
+                      formatter={(value, name) => [`${value} ${name}`, "Amount"]}
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+              )}
             </div>
+            {assetBreakdown.length > 0 && (
+              <div className="mt-4 border-t border-white/10 pt-4 text-center">
+                <p className="text-[10px] uppercase tracking-widest text-steel">Total Earned</p>
+                <p className="mt-1 text-xl font-bold text-white tabular-nums">
+                  {assetTotal.toLocaleString(undefined, { maximumFractionDigits: 7 })}
+                </p>
+              </div>
+            )}
           </motion.div>
         </div>
 

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -4,6 +4,7 @@ import { AppShell } from "@/components/app-shell";
 import { ProfileCard } from "@/components/profile-card";
 import { SupportPanel } from "@/components/support-panel";
 import { ProfileTabs } from "@/components/profile-tabs";
+import { QRCodeButton } from "@/components/qr-code-button";
 import { API_BASE_URL } from "@/lib/config";
 
 type PageProps = {
@@ -179,12 +180,22 @@ async function getStats(username: string): Promise<ProfileStats | null> {
   return res.json();
 }
 
+async function getMilestones(username: string): Promise<Milestone[]> {
+  const res = await fetch(`${API_BASE_URL}/profiles/${username}/milestones`, {
+    next: { revalidate: 60 },
+  });
+  if (!res.ok) return [];
+  const body = await res.json();
+  return body.milestones ?? body ?? [];
+}
+
 export default async function ProfilePage({ params }: PageProps) {
-  const [profile, transactions, leaderboard, stats] = await Promise.all([
+  const [profile, transactions, leaderboard, stats, milestones] = await Promise.all([
     getProfile(params.username),
     getTransactions(params.username, 10),
     getLeaderboard(params.username),
     getStats(params.username),
+    getMilestones(params.username),
   ]);
 
   const activeMilestones = milestones.filter((m) => m.status === "active");
@@ -193,15 +204,20 @@ export default async function ProfilePage({ params }: PageProps) {
     <AppShell>
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8 items-start">
         <div className="space-y-12">
-          <ProfileCard
-            username={profile.username}
-            displayName={profile.displayName}
-            bio={profile.bio}
-            walletAddress={profile.walletAddress}
-            acceptedAssets={profile.acceptedAssets}
-            avatarUrl={profile.avatarUrl || undefined}
-            stats={stats || undefined}
-          />
+          <div className="space-y-3">
+            <ProfileCard
+              username={profile.username}
+              displayName={profile.displayName}
+              bio={profile.bio}
+              walletAddress={profile.walletAddress}
+              acceptedAssets={profile.acceptedAssets}
+              avatarUrl={profile.avatarUrl || undefined}
+              stats={stats || undefined}
+            />
+            <div className="px-2">
+              <QRCodeButton username={profile.username} />
+            </div>
+          </div>
 
           {activeMilestones.length > 0 && (
             <div className="px-2 space-y-4">

--- a/frontend/src/components/qr-code-button.tsx
+++ b/frontend/src/components/qr-code-button.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { QrCode, X } from "lucide-react";
+
+type QRCodeButtonProps = {
+  username: string;
+};
+
+export function QRCodeButton({ username }: QRCodeButtonProps) {
+  const [open, setOpen] = useState(false);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const profileUrl = `https://novasupport.xyz/profile/${username}`;
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+
+    function handleClickOutside(e: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label="Show QR code"
+        className="inline-flex items-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-medium text-sky/80 transition hover:bg-white/10 hover:text-white"
+      >
+        <QrCode size={14} />
+        QR Code
+      </button>
+
+      {open && (
+        <div
+          ref={popoverRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Profile QR code"
+          className="absolute left-0 top-full z-50 mt-2 rounded-2xl border border-white/10 bg-[#0A0A0B] p-5 shadow-2xl"
+        >
+          <div className="mb-3 flex items-center justify-between gap-6">
+            <p className="text-xs font-semibold uppercase tracking-widest text-steel">
+              Scan to support
+            </p>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close QR code"
+              className="rounded-lg p-1 text-steel transition hover:text-white"
+            >
+              <X size={14} />
+            </button>
+          </div>
+          <div className="rounded-xl bg-white p-3">
+            <QRCodeSVG value={profileUrl} size={160} />
+          </div>
+          <p className="mt-3 max-w-[160px] break-all text-center text-[10px] text-steel">
+            {profileUrl}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **#221 [Backend] Webhook delivery on support transaction** — After each support transaction is recorded, all active webhooks registered for the profile are called with a fire-and-forget HTTP POST. Payload includes `event`, `txHash`, `amount`, `assetCode`, `message`, `profileUsername`, and `createdAt`. Each request is signed with an HMAC-SHA256 header (`X-NovaSupport-Signature`) using the webhook's secret. Delivery success/failure is logged via pino. A new `Webhook` Prisma model and migration are included.

- **#215 [Frontend] Asset breakdown chart on dashboard** — Adds a dedicated `GET /profiles/:username/analytics/assets` backend endpoint returning per-asset totals and percentages. The dashboard Asset Distribution chart now fetches from this endpoint, renders percentage labels on each pie slice, shows the total earned below the chart, and displays a proper empty state when there are no earnings.

- **#211 [Frontend] QR code on public profile page** — Installs `qrcode.react` and adds a `QRCodeButton` client component to the profile page. Clicking opens a popover with a QR code encoding `https://novasupport.xyz/profile/{username}` and a "Scan to support" label. The popover closes on Escape or outside click. Also fixes a pre-existing runtime bug where `milestones` was referenced before being fetched — added `getMilestones` and included it in the `Promise.all`.

Closes #221
Closes  #215
Closes #211