### PR TITLE
feat: add Freighter signTransaction() call to SupportPanel

### DIFF
--- a/frontend/src/components/support-panel.test.tsx
+++ b/frontend/src/components/support-panel.test.tsx
@@ -88,6 +88,53 @@ describe('SupportPanel', () => {
     expect(screen.getByText('12345678...90abcdef')).toBeInTheDocument();
   });
 
+  it('shows "Waiting for Freighter signature…" while signing prompt is open', async () => {
+    vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
+    // Never resolves — simulates Freighter prompt staying open
+    vi.mocked(signTransaction).mockReturnValue(new Promise(() => {}));
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Waiting for Freighter signature/i })).toBeDisabled(),
+    );
+  });
+
+  it('shows a readable error when the user rejects the transaction in Freighter', async () => {
+    vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
+    vi.mocked(signTransaction).mockRejectedValue(new Error('User declined signing the transaction'));
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
+    await waitFor(() =>
+      expect(screen.getByText('You declined the transaction in Freighter.')).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
+  it('shows a readable error when Freighter is not installed', async () => {
+    vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
+    vi.mocked(signTransaction).mockRejectedValue(new Error('Freighter is not installed'));
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Freighter is not installed/i),
+      ).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+  });
+
   it('shows a readable Horizon error message', async () => {
     vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
     vi.mocked(signTransaction).mockResolvedValue({
@@ -104,6 +151,21 @@ describe('SupportPanel', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
     fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
     await waitFor(() => expect(screen.getByText('Transaction expired')).toBeInTheDocument(), { timeout: 3000 });
+  });
+
+  it('button is disabled while the signing prompt is open', async () => {
+    vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
+    vi.mocked(signTransaction).mockReturnValue(new Promise(() => {}));
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Waiting for Freighter signature/i });
+      expect(btn).toBeDisabled();
+    });
   });
 
   it('renders payment asset selector when connected', async () => {

--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -44,6 +44,7 @@ export function SupportPanel({
   const [amount, setAmount] = useState("");
   const [isSigning, setIsSigning] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [signedXdr, setSignedXdr] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [submittedHash, setSubmittedHash] = useState<string | null>(null);
   const [showResultModal, setShowResultModal] = useState(false);
@@ -214,6 +215,40 @@ export function SupportPanel({
     return "Unable to submit transaction to Stellar. Please try again.";
   }
 
+  function mapFreighterError(error: unknown): string {
+    const msg =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : "";
+
+    const lower = msg.toLowerCase();
+
+    if (
+      lower.includes("user declined") ||
+      lower.includes("user rejected") ||
+      lower.includes("rejected") ||
+      lower.includes("declined")
+    ) {
+      return "You declined the transaction in Freighter.";
+    }
+
+    if (
+      lower.includes("not installed") ||
+      lower.includes("no freighter") ||
+      lower.includes("freighter is not")
+    ) {
+      return "Freighter is not installed. Please install the Freighter browser extension and try again.";
+    }
+
+    if (lower.includes("not allowed") || lower.includes("permission")) {
+      return "Freighter access was not granted. Please allow the site in Freighter and try again.";
+    }
+
+    return msg || "Freighter did not return a signed transaction.";
+  }
+
   async function handleSendSupport() {
     if (!visitorAddress || !isValidAmount || isProcessing || noPathFound) {
       return;
@@ -221,8 +256,11 @@ export function SupportPanel({
 
     setErrorMessage(null);
     setSubmittedHash(null);
+    setSignedXdr(null);
     setRecurringError(null);
     setIsSigning(true);
+
+    let resolvedSignedXdr: string;
 
     try {
       const isSameAsset =
@@ -261,6 +299,7 @@ export function SupportPanel({
         });
       }
 
+      // Open Freighter signing prompt — user sees "Waiting for Freighter signature…"
       const signedResult = await signTransaction(unsignedXdr, {
         address: visitorAddress,
         networkPassphrase: stellarConfig.networkPassphrase,
@@ -273,11 +312,21 @@ export function SupportPanel({
         );
       }
 
+      // Store the signed XDR in state for the broadcast step
+      resolvedSignedXdr = signedResult.signedTxXdr;
+      setSignedXdr(resolvedSignedXdr);
+    } catch (signingError) {
+      setErrorMessage(mapFreighterError(signingError));
       setIsSigning(false);
-      setIsSubmitting(true);
+      return;
+    }
 
+    setIsSigning(false);
+    setIsSubmitting(true);
+
+    try {
       const transactionToSubmit = TransactionBuilder.fromXDR(
-        signedResult.signedTxXdr,
+        resolvedSignedXdr,
         stellarConfig.networkPassphrase,
       );
 


### PR DESCRIPTION
- Add signedXdr state to store signed transaction XDR
- Split signing and submission into separate steps
- Add mapFreighterError() for user-friendly error messages
- Handle user rejection with explicit error message
- Handle Freighter not installed with explicit error message
- Show 'Waiting for Freighter signature...' state while signing
- Disable button while signing prompt is open
- Add comprehensive tests for signing flow and error cases

closes #180 

