### PR TITLE
feat: add Freighter install prompt when wallet extension is not detected

### DIFF
--- a/frontend/src/components/wallet-connect.test.tsx
+++ b/frontend/src/components/wallet-connect.test.tsx
@@ -55,7 +55,26 @@ describe('WalletConnect', () => {
     expect(screen.getByText(/GAAAAA/)).toBeInTheDocument();
   });
 
-  it('shows not installed message when Freighter is not available', async () => {
+  it('shows install prompt with link when Freighter is not available', async () => {
+    (window as any).stellarLumens = undefined;
+    
+    render(<WalletConnect />);
+    
+    const button = screen.queryByRole('button', { name: 'Connect Freighter' });
+    fireEvent.click(button!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Freighter wallet required/)).toBeInTheDocument();
+    });
+    
+    const installLink = screen.getByRole('link', { name: /Install Freighter/i });
+    expect(installLink).toBeInTheDocument();
+    expect(installLink).toHaveAttribute('href', 'https://freighter.app');
+    expect(installLink).toHaveAttribute('target', '_blank');
+    expect(installLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not render connect button when Freighter is not installed', async () => {
     (window as any).stellarLumens = undefined;
     
     render(<WalletConnect />);
@@ -64,8 +83,10 @@ describe('WalletConnect', () => {
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(screen.getByText(/Freighter wallet is not installed/)).toBeInTheDocument();
+      expect(screen.getByText(/Freighter wallet required/)).toBeInTheDocument();
     });
-    expect(screen.getByText(/Install it here/)).toBeInTheDocument();
+    
+    // Button should not be visible after detecting Freighter is not installed
+    expect(screen.queryByRole('button', { name: 'Connect Freighter' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/wallet-connect.tsx
+++ b/frontend/src/components/wallet-connect.tsx
@@ -117,13 +117,14 @@ export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
           <div className="mt-2 text-sm text-sky/80">
             {errorType === "not_installed" && (
               <p>
-                Freighter wallet is not installed.{" "}
+                Freighter wallet required.{" "}
                 <a
                   href="https://freighter.app"
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="text-mint underline decoration-mint/30 underline-offset-4 hover:decoration-mint"
                 >
-                  Install it here →
+                  Install Freighter
                 </a>
               </p>
             )}
@@ -145,13 +146,15 @@ export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
             {!errorType && <p>{status}</p>}
           </div>
         </div>
-        <button
-          type="button"
-          onClick={address ? disconnectWallet : connectWallet}
-          className="rounded-full bg-mint px-4 py-2 text-sm font-semibold text-ink transition hover:bg-white"
-        >
-          {address ? "Disconnect" : "Connect Freighter"}
-        </button>
+        {errorType !== "not_installed" && (
+          <button
+            type="button"
+            onClick={address ? disconnectWallet : connectWallet}
+            className="rounded-full bg-mint px-4 py-2 text-sm font-semibold text-ink transition hover:bg-white"
+          >
+            {address ? "Disconnect" : "Connect Freighter"}
+          </button>
+        )}
       </div>
       {address ? (
         <div className="mt-4 rounded-2xl border border-mint/30 bg-ink/50 p-3 text-sm text-white">


### PR DESCRIPTION
- Update install prompt text to 'Freighter wallet required'
- Change link text to 'Install Freighter' for clarity
- Add rel='noopener noreferrer' for security
- Hide connect button when Freighter is not installed
- Update tests to verify install prompt and link attributes
- Add test to verify button is hidden when not installed

Acceptance criteria met:
✅ Install prompt renders with link to freighter.app ✅ Link opens in new tab with proper security attributes ✅ Connect button does not render when Freighter not installed ✅ Existing connected state unchanged
✅ Tests updated and passing

closes #151 

