### PR TITLE
feat: update bio character counter to turn red within 10 chars of limit

### DIFF
--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -244,7 +244,7 @@ export default function CreatePage() {
                     </label>
                     <span
                       className={`text-[10px] tabular-nums ${
-                        form.bio.length >= 260 ? "text-gold" : "text-steel/50"
+                        form.bio.length >= 270 ? "text-red-400" : "text-steel/50"
                       }`}
                     >
                       {form.bio.length}&nbsp;/&nbsp;280


### PR DESCRIPTION
- Change counter color from gold to red when within 10 characters of limit
- Counter now turns red at 270 characters (280 - 10)
- Matches backend Zod validation limit of 280 characters
- Counter updates live on every keystroke
- Positioned above textarea for better visibility

Acceptance criteria met:
✅ Character counter appears and updates on every keystroke ✅ Counter turns red when within 10 characters of limit (270+) ✅ Limit matches backend Zod validation (280 chars) ✅ No new dependencies needed

closes #145
