### PR TITLE
feat: add automated Lighthouse CI for frontend performance (#284)

### DIFF
--- a/.github/workflows/frontend-validation.yml
+++ b/.github/workflows/frontend-validation.yml
@@ -43,3 +43,36 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: frontend
+
+  lighthouse:
+    name: Lighthouse CI
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build
+        run: npm run build
+        working-directory: frontend
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          workingDirectory: ./frontend
+          configPath: ./frontend/lighthouserc.js
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/frontend-validation.yml
+++ b/.github/workflows/frontend-validation.yml
@@ -1,7 +1,7 @@
 name: Frontend CI
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-validation.yml"

--- a/frontend/lighthouserc.js
+++ b/frontend/lighthouserc.js
@@ -1,0 +1,26 @@
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'npm run start',
+      url: ['http://localhost:3000/'],
+      numberOfRuns: 3,
+      settings: {
+        preset: 'desktop',
+      },
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['error', { minScore: 0.9 }],
+        'categories:accessibility': ['warn', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.9 }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 2500 }],
+        'cumulative-layout-shift': ['error', { maxNumericValue: 0.1 }],
+        'total-blocking-time': ['error', { maxNumericValue: 300 }],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};


### PR DESCRIPTION
Closes #284. This PR adds Lighthouse CI to measure and track performance metrics on every frontend PR. It includes performance thresholds for LCP, CLS, and TBT.