### PR TITLE
feat: add database migration validation to CI (#285)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -64,6 +64,16 @@ jobs:
       - name: Apply database migrations
         run: npm run db:migrate:deploy
 
+      - name: Validate database migrations
+        run: |
+          npx prisma migrate diff \
+            --from-schema-datamodel prisma/schema.prisma \
+            --to-migrations prisma/migrations \
+            --shadow-database-url "$DATABASE_URL" \
+            --exit-code
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+
       - name: Run backend tests
         run: npm run test
 


### PR DESCRIPTION
Closes #285. This PR adds a step to the backend CI to validate that Prisma migrations are up-to-date with schema changes using prisma migrate diff.