### PR TITLE
Add frontend PR workflow (lint + build check)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,33 @@
+name: Frontend CI
+
+on:
+  pull_request_target:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend.yml"
+
+jobs:
+  frontend:
+    name: Frontend checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build


### PR DESCRIPTION
- Created .github/workflows/frontend.yml for frontend CI
- Runs on pull_request_target for PRs touching frontend/
- Runs on push to main branch
- Executes npm ci, npm run lint, and npm run build
- Uses Node.js 20.x with npm caching
- Lint errors will fail the workflow
- Build errors will fail the workflow
- Consistent with backend workflow pattern using pull_request_target

closes #227
closes #80 


