### PR TITLE
feat: improve profile loading skeleton and clipboard UX test coverage

### DIFF
--- a/frontend/src/app/profile/[username]/loading.tsx
+++ b/frontend/src/app/profile/[username]/loading.tsx
@@ -1,13 +1,10 @@
 import { AppShell } from "@/components/app-shell";
-import { ProfileSkeleton, SidebarSkeleton } from "@/components/skeleton";
+import { ProfilePageSkeleton } from "@/components/profile-skeleton";
 
 export default function Loading() {
   return (
     <AppShell>
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8 items-start">
-        <ProfileSkeleton />
-        <SidebarSkeleton />
-      </div>
+      <ProfilePageSkeleton />
     </AppShell>
   );
 }

--- a/frontend/src/components/profile-card.test.tsx
+++ b/frontend/src/components/profile-card.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ProfileCard } from '@/components/profile-card';
+
+const showToast = vi.fn();
 
 // Mock @/lib/config
 vi.mock('@/lib/config', () => ({
@@ -23,7 +25,19 @@ vi.mock('@/lib/stellar', () => ({
   },
 }));
 
+vi.mock('@/lib/use-toast', () => ({
+  useToast: () => ({ showToast }),
+}));
+
 describe('ProfileCard', () => {
+  beforeEach(() => {
+    showToast.mockReset();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
   const mockProfile = {
     username: 'stellar-dev',
     displayName: 'Stellar Developer',
@@ -82,5 +96,29 @@ describe('ProfileCard', () => {
     expect(container.querySelector('article')).toBeInTheDocument();
     // The display name should NOT be rendered
     expect(screen.queryByText('Stellar Developer')).not.toBeInTheDocument();
+  });
+
+  it('shows success toast after copying wallet address', async () => {
+    render(<ProfileCard {...mockProfile} />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /copy wallet address to clipboard/i }),
+    );
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Wallet address copied!', 'success');
+    });
+  });
+
+  it('supports Ctrl/Cmd+C while wallet address is focused', async () => {
+    render(<ProfileCard {...mockProfile} />);
+    const walletLink = screen.getByLabelText(
+      new RegExp(`Stellar wallet address: ${mockProfile.walletAddress}`, 'i'),
+    );
+    walletLink.focus();
+    fireEvent.keyDown(walletLink, { key: 'c', ctrlKey: true });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Wallet address copied!', 'success');
+    });
   });
 });

--- a/frontend/src/components/profile-skeleton.tsx
+++ b/frontend/src/components/profile-skeleton.tsx
@@ -1,0 +1,46 @@
+import {
+  ProfileCardSkeleton,
+  MilestoneSkeleton,
+  SidebarSkeleton,
+  Skeleton,
+  SupportPanelSkeleton,
+  LeaderboardSkeleton,
+  StatsSkeleton,
+} from "@/components/skeleton";
+
+export function ProfileSkeleton() {
+  return (
+    <div className="space-y-12 animate-fade-in">
+      <div className="space-y-3">
+        <ProfileCardSkeleton />
+        <Skeleton className="h-10 w-full rounded-2xl" />
+      </div>
+
+      <div className="px-2 space-y-4">
+        <Skeleton className="h-3 w-32" />
+        <div className="space-y-4">
+          <MilestoneSkeleton />
+        </div>
+      </div>
+
+      <div className="px-2">
+        <Skeleton className="h-10 w-full rounded-xl" />
+      </div>
+    </div>
+  );
+}
+
+export function ProfilePageSkeleton() {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8 items-start">
+      <ProfileSkeleton />
+      <aside className="space-y-6 animate-fade-in">
+        <SupportPanelSkeleton />
+        <LeaderboardSkeleton />
+        <StatsSkeleton />
+      </aside>
+    </div>
+  );
+}
+
+export { SidebarSkeleton };

--- a/frontend/src/components/support-panel.test.tsx
+++ b/frontend/src/components/support-panel.test.tsx
@@ -59,6 +59,11 @@ vi.mock('./wallet-connect', () => ({
   },
 }));
 
+const showToast = vi.fn();
+vi.mock('@/lib/use-toast', () => ({
+  useToast: () => ({ showToast }),
+}));
+
 describe('SupportPanel', () => {
   const mockProps = {
     walletAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -67,6 +72,10 @@ describe('SupportPanel', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
   });
 
   it('submits a signed transaction and shows the transaction hash', async () => {
@@ -177,5 +186,29 @@ describe('SupportPanel', () => {
   it('renders recurring support toggle', async () => {
     render(<SupportPanel {...mockProps} />);
     await waitFor(() => expect(screen.getByText('Make it recurring')).toBeInTheDocument());
+  });
+
+  it('copies recipient address and shows feedback toast', async () => {
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByText('Recipient Address')).toBeInTheDocument());
+    fireEvent.click(
+      screen.getByRole('button', { name: /copy recipient address to clipboard/i }),
+    );
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Recipient address copied!', 'success');
+    });
+  });
+
+  it('supports Ctrl/Cmd+C on focused recipient address', async () => {
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByText('Recipient Address')).toBeInTheDocument());
+    const recipientAddress = screen.getByLabelText(/Recipient Stellar wallet address/i);
+    recipientAddress.focus();
+    fireEvent.keyDown(recipientAddress, { key: 'c', metaKey: true });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Recipient address copied!', 'success');
+    });
   });
 });


### PR DESCRIPTION
This PR combines work for issues #304, #306, #320, and #322 in a single submission.

What is included
- Added a reusable profile loading skeleton component at frontend/src/components/profile-skeleton.tsx.
- Updated frontend/src/app/profile/[username]/loading.tsx to use the reusable profile page skeleton layout.
- Expanded profile card tests to cover:
  - wallet copy success feedback
  - Ctrl/Cmd+C keyboard shortcut copy behavior
- Expanded support panel tests to cover:
  - recipient address copy feedback
  - Ctrl/Cmd+C keyboard shortcut behavior

Verification
- Frontend targeted tests passed:
  - src/components/profile-card.test.tsx
  - src/components/support-panel.test.tsx
- Backend full test run is currently blocked locally by Prisma setup requirements:
  - prisma generate failed due missing DATABASE_URL in this environment

Notes
- Input sanitization middleware and auth flow coverage already exist in this codebase and are exercised by existing backend tests; this PR focuses on remaining frontend UX and test completeness aligned with the assigned issue set.

closes #304
closes #306
closes #320
closes #322