### PR TITLE
feat: validate pagination parameters and update API docs

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -119,7 +119,12 @@ function sendError(
 
 export function createApp(customLogger?: Logger) {
   const app = express();
-  const { globalLimiter, writeLimiter, profileCreationLimiter } = createRateLimiters();
+  const { globalLimiter, writeLimiter, profileCreationLimiter, resendLimiter } = createRateLimiters();
+
+  const paginationSchema = z.object({
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+    offset: z.coerce.number().int().min(0).default(0),
+  });
 
   const swaggerSpec = swaggerJsdoc({
     definition: {
@@ -401,13 +406,16 @@ export function createApp(customLogger?: Logger) {
    *         name: limit
    *         schema:
    *           type: integer
+   *           minimum: 1
+   *           maximum: 100
    *           default: 20
    *           example: 20
-   *         description: Number of profiles to return
+   *         description: Number of profiles to return (Min: 1, Max: 100)
    *       - in: query
    *         name: offset
    *         schema:
    *           type: integer
+   *           minimum: 0
    *           default: 0
    *           example: 0
    *         description: Number of profiles to skip
@@ -458,8 +466,11 @@ export function createApp(customLogger?: Logger) {
    */
   app.get("/profiles", async (req, res) => {
     try {
-      const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
-      const offset = parseInt(req.query.offset as string) || 0;
+      const pagination = paginationSchema.safeParse(req.query);
+      if (!pagination.success) {
+        return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+      }
+      const { limit, offset } = pagination.data;
       const rawSearch =
         typeof req.query.search === "string" ? req.query.search : "";
       const search = rawSearch.trim().slice(0, 100);
@@ -1281,12 +1292,17 @@ export function createApp(customLogger?: Logger) {
    *         name: limit
    *         schema:
    *           type: integer
+   *           minimum: 1
+   *           maximum: 100
    *           default: 20
+   *         description: Number of transactions to return (Min: 1, Max: 100)
    *       - in: query
    *         name: offset
    *         schema:
    *           type: integer
+   *           minimum: 0
    *           default: 0
+   *         description: Number of transactions to skip (Min: 0)
    *       - in: query
    *         name: network
    *         schema:
@@ -1300,9 +1316,12 @@ export function createApp(customLogger?: Logger) {
    *         description: Internal server error
    */
   app.get("/profiles/:username/transactions", async (req, res) => {
+    const pagination = paginationSchema.safeParse(req.query);
+    if (!pagination.success) {
+      return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+    }
+    const { limit, offset } = pagination.data;
     const { username } = req.params;
-    const limit = Math.min(parseInt(req.query.limit as string) || 20, 1000);
-    const offset = parseInt(req.query.offset as string) || 0;
     const network = req.query.network as string | undefined;
     const status = req.query.status as string | undefined;
     const assetCode = req.query.assetCode as string | undefined;
@@ -1339,8 +1358,11 @@ export function createApp(customLogger?: Logger) {
 
   // Issue #204 — GET /profiles (explore page, paginated + sortable + asset filter)
   app.get("/profiles", async (req, res) => {
-    const limit = Math.min(parseInt(req.query.limit as string) || 20, 50);
-    const offset = parseInt(req.query.offset as string) || 0;
+    const pagination = paginationSchema.safeParse(req.query);
+    if (!pagination.success) {
+      return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+    }
+    const { limit, offset } = pagination.data;
     const sort = (req.query.sort as string) || "newest";
     const asset = req.query.asset as string | undefined;
 
@@ -1441,10 +1463,53 @@ export function createApp(customLogger?: Logger) {
     return res.status(204).send();
   });
 
+  /**
+   * @openapi
+   * /profiles/{username}/leaderboard:
+   *   get:
+   *     summary: Get profile supporter leaderboard
+   *     parameters:
+   *       - in: path
+   *         name: username
+   *         required: true
+   *         schema:
+   *           type: string
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 100
+   *           default: 20
+   *         description: Number of entries to return (Min: 1, Max: 100)
+   *       - in: query
+   *         name: offset
+   *         schema:
+   *           type: integer
+   *           minimum: 0
+   *           default: 0
+   *         description: Number of entries to skip (Min: 0)
+   *       - in: query
+   *         name: sort
+   *         schema:
+   *           type: string
+   *           enum: [total_amount, transaction_count]
+   *           default: total_amount
+   *     responses:
+   *       200:
+   *         description: Leaderboard data
+   *       404:
+   *         description: Profile not found
+   *       500:
+   *         description: Internal server error
+   */
   app.get("/profiles/:username/leaderboard", async (req, res) => {
+    const pagination = paginationSchema.safeParse(req.query);
+    if (!pagination.success) {
+      return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+    }
+    const { limit, offset } = pagination.data;
     const { username } = req.params;
-    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 10, 1), 100);
-    const offset = Math.max(parseInt(req.query.offset as string) || 0, 0);
     const sort =
       req.query.sort === "transaction_count"
         ? "transaction_count"
@@ -1813,6 +1878,21 @@ export function createApp(customLogger?: Logger) {
    *         required: true
    *         schema:
    *           type: string
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 100
+   *           default: 20
+   *         description: Number of recent transactions to return (Min: 1, Max: 100)
+   *       - in: query
+   *         name: offset
+   *         schema:
+   *           type: integer
+   *           minimum: 0
+   *           default: 0
+   *         description: Number of recent transactions to skip (Min: 0)
    *     responses:
    *       200:
    *         description: Analytics data
@@ -1820,11 +1900,12 @@ export function createApp(customLogger?: Logger) {
    *         description: Analytics not found
    */
   app.get("/analytics/:campaignId", async (req, res) => {
-    // Analytics endpoint — returns summary + recent transactions with pagination
+    const pagination = paginationSchema.safeParse(req.query);
+    if (!pagination.success) {
+      return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+    }
+    const { limit, offset } = pagination.data;
     const { campaignId } = req.params;
-
-    const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
-    const offset = parseInt(req.query.offset as string) || 0;
 
     // Attempt to find a profile by username (campaignId maps to username)
     const profile = await prisma.profile.findUnique({


### PR DESCRIPTION
## Summary

closes #380 

This PR introduces robust validation for pagination parameters (`limit` and `offset`) across all paginated API endpoints. This prevents performance issues caused by excessively large limits or negative offsets.

## Changes

### Backend
- **Standardized Pagination Schema**: Defined a reusable `paginationSchema` using Zod in `backend/src/app.ts`.
    - `limit`: Integer, Min 1, Max 100, Default 20.
    - `offset`: Integer, Min 0, Default 0.
- **Enforced Validation**: Integrated the schema into the following endpoints:
    - `GET /profiles` (Search/Filter)
    - `GET /profiles/:username/transactions`
    - `GET /profiles` (Explore)
    - `GET /profiles/:username/leaderboard`
    - `GET /analytics/:campaignId`
- **Error Handling**: Endpoints now return a `400 Bad Request` with the code `INVALID_PAGINATION` if the parameters do not meet the criteria.
- **API Documentation**: Updated OpenAPI (Swagger) comments for all paginated endpoints to document the new constraints (Min/Max values).

## Verification
- **Logic Review**: Confirmed that the `z.coerce.number()` correctly handles string input from query parameters.
- **Coverage**: Verified that all endpoints identified as having `limit` and `offset` parameters were updated.