### PR TITLE
fix: change pull_request_target to pull_request for automatic workflo…

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,7 +1,7 @@
 name: Backend CI
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "backend/**"
       - ".github/workflows/backend.yml"

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,7 +1,7 @@
 name: Contract CI
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "contract/**"
       - ".github/workflows/contract.yml"


### PR DESCRIPTION
# Fix workflow approval requirement for pull requests

Closes #373

## 🎯 Changes

Changed workflow triggers from `pull_request_target` to `pull_request` in:
- `.github/workflows/backend.yml`
- `.github/workflows/contract.yml`

## 🔍 Why this change?

`pull_request_target` runs workflows in the context of the base repository and requires manual approval for security reasons. This slows down PR reviews.

`pull_request` runs workflows automatically on PR creation while still maintaining security through:
- Explicit ref checkout: `ref: ${{ github.event.pull_request.head.sha || github.sha }}`
- Running in the PR's context with limited permissions
- Path filters to only trigger on relevant file changes

## ✅ Testing

- [x] Workflows trigger automatically on PR creation
- [x] Security maintained with proper ref checkout
- [x] All existing checks still pass
- [x] No manual approval required

