### PR TITLE
feat: add multi-wallet support and Lighthouse CI (#343, #344)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend.yml"
+      - "lighthouserc.js"
   push:
     branches:
       - main
     paths:
       - "frontend/**"
       - ".github/workflows/frontend.yml"
+      - "lighthouserc.js"
 
 jobs:
   frontend:
@@ -31,3 +33,27 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
+
+  lighthouse:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    # Only run on PRs to avoid burning CI minutes on every push to main
+    if: github.event_name == 'pull_request_target'
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - name: Run Lighthouse CI
+        run: npx @lhci/cli@0.14.x autorun --config=../lighthouserc.js
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -44,14 +44,13 @@ export function ProfileCard({
   githubHandle,
   stats,
   isVerified,
+  isLoading,
 }: ProfileCardProps & { isVerified?: boolean }) {
   const [copied, setCopied] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const [resending, setResending] = useState(false);
-
-  if (isLoading) return <ProfileCardSkeleton />;
-
   const { showToast } = useToast();
+
   const isValid = isValidStellarAddress(walletAddress);
   const hasSocialLinks = email || websiteUrl || twitterHandle || githubHandle;
 
@@ -133,6 +132,8 @@ export function ProfileCard({
   const tweetUrl = `https://twitter.com/intent/tweet?text=${tweetText}`;
 
   const expertUrl = `https://stellar.expert/explorer/testnet/account/${walletAddress}`;
+
+  if (isLoading) return <ProfileCardSkeleton />;
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/wallet-connect.tsx
+++ b/frontend/src/components/wallet-connect.tsx
@@ -1,13 +1,19 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { getAddress, isAllowed, setAllowed } from "@stellar/freighter-api";
+import { useState, useEffect, useCallback } from "react";
+import {
+  getAvailableWallets,
+  getWalletAdapter,
+  type WalletAdapter,
+  type WalletId,
+} from "@/lib/wallet-adapters";
 
 function truncateAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(-6)}`;
 }
 
 const STORAGE_KEY = "walletAddress";
+const STORAGE_WALLET_ID = "walletId";
 
 type WalletConnectProps = {
   onConnect?: (address: string) => void;
@@ -15,98 +21,60 @@ type WalletConnectProps = {
 
 export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
   const [address, setAddress] = useState<string | null>(null);
-  const [status, setStatus] = useState("Connect Freighter to preview Stellar Testnet support.");
-  const [errorType, setErrorType] = useState<"not_installed" | "denied" | "wrong_network" | null>(null);
+  const [activeWallet, setActiveWallet] = useState<WalletId | null>(null);
+  const [available, setAvailable] = useState<WalletAdapter[]>([]);
+  const [status, setStatus] = useState("Choose a wallet to connect.");
+  const [error, setError] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
 
-  // Restore from localStorage on mount and verify against Freighter
+  // Detect available wallets client-side only
   useEffect(() => {
-    const restoreWallet = async () => {
-      if (typeof window === "undefined") return;
+    setAvailable(getAvailableWallets());
+  }, []);
 
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (!saved) return;
-
-      try {
-        // Check if Freighter is available and allowed
-        const access = await isAllowed();
-        if (!access.isAllowed) return;
-
-        const result = await getAddress();
-        if (result.error || !result.address) return;
-
-        // If Freighter returns a different address, update to the new one
-        if (result.address !== saved) {
-          localStorage.setItem(STORAGE_KEY, result.address);
-        }
-
-        setAddress(result.address);
-        setStatus("Freighter connected on Stellar Testnet.");
-        onConnect?.(result.address);
-      } catch {
-        // Silent fail - user will need to reconnect manually
-        localStorage.removeItem(STORAGE_KEY);
-      }
-    };
-
-    restoreWallet();
+  // Restore persisted session
+  useEffect(() => {
+    const savedAddress = localStorage.getItem(STORAGE_KEY);
+    const savedWalletId = localStorage.getItem(STORAGE_WALLET_ID) as WalletId | null;
+    if (savedAddress && savedWalletId) {
+      setAddress(savedAddress);
+      setActiveWallet(savedWalletId);
+      setStatus(`${savedWalletId.charAt(0).toUpperCase() + savedWalletId.slice(1)} connected.`);
+      onConnect?.(savedAddress);
+    }
   }, [onConnect]);
 
-  async function connectWallet() {
-    setErrorType(null);
+  const connectWallet = useCallback(async (walletId: WalletId) => {
+    const adapter = getWalletAdapter(walletId);
+    if (!adapter) return;
+
+    setConnecting(true);
+    setError(null);
+    setStatus(`Connecting to ${adapter.name}…`);
+
     try {
-      setStatus("Checking Freighter availability...");
-
-      if (typeof window !== "undefined" && (window as any).stellarLumens === undefined) {
-        setErrorType("not_installed");
-        setStatus("Freighter not found.");
-        return;
-      }
-
-      const access = await isAllowed();
-      if (!access.isAllowed) {
-        const permission = await setAllowed();
-        if (!permission.isAllowed) {
-          setErrorType("denied");
-          setStatus("Permission denied.");
-          return;
-        }
-      }
-
-      const result = await getAddress();
-      if (result.error) {
-        if (result.error.toLowerCase().includes("network")) {
-          setErrorType("wrong_network");
-          setStatus("Wrong network.");
-        } else {
-          setStatus(result.error);
-        }
-        return;
-      }
-
-      // Save to localStorage on successful connection
-      if (typeof window !== "undefined") {
-        localStorage.setItem(STORAGE_KEY, result.address);
-      }
-
-      setAddress(result.address);
-      setStatus("Freighter connected on Stellar Testnet.");
-      onConnect?.(result.address);
-    } catch (error) {
-      setStatus(
-        error instanceof Error
-          ? error.message
-          : "Unable to connect to Freighter."
-      );
+      const pubkey = await adapter.connect();
+      localStorage.setItem(STORAGE_KEY, pubkey);
+      localStorage.setItem(STORAGE_WALLET_ID, walletId);
+      setAddress(pubkey);
+      setActiveWallet(walletId);
+      setStatus(`${adapter.name} connected on Stellar Testnet.`);
+      onConnect?.(pubkey);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to connect ${adapter.name}.`);
+      setStatus("Connection failed.");
+    } finally {
+      setConnecting(false);
     }
-  }
+  }, [onConnect]);
 
   function disconnectWallet() {
-    if (typeof window !== "undefined") {
-      localStorage.removeItem(STORAGE_KEY);
-    }
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(STORAGE_WALLET_ID);
     setAddress(null);
-    setStatus("Connect Freighter to preview Stellar Testnet support.");
-    setErrorType(null);
+    setActiveWallet(null);
+    setError(null);
+    setStatus("Choose a wallet to connect.");
   }
 
   return (
@@ -115,52 +83,59 @@ export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
         <div>
           <p className="text-xs uppercase tracking-[0.25em] text-mint">Wallet</p>
           <div className="mt-2 text-sm text-sky/80">
-            {errorType === "not_installed" && (
-              <p>
-                Freighter wallet required.{" "}
-                <a
-                  href="https://freighter.app"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-mint underline decoration-mint/30 underline-offset-4 hover:decoration-mint"
-                >
-                  Install Freighter
-                </a>
-              </p>
-            )}
-            {errorType === "denied" && (
-              <p>
-                Connection was denied. Please approve in Freighter and{" "}
-                <button
-                  onClick={connectWallet}
-                  className="text-mint underline decoration-mint/30 underline-offset-4 hover:decoration-mint"
-                >
-                  try again
-                </button>
-                .
-              </p>
-            )}
-            {errorType === "wrong_network" && (
-              <p>Please switch Freighter to Testnet in wallet settings.</p>
-            )}
-            {!errorType && <p>{status}</p>}
+            {error ? <p className="text-red-400">{error}</p> : <p>{status}</p>}
           </div>
         </div>
-        {errorType !== "not_installed" && (
+        {address && (
           <button
             type="button"
-            onClick={address ? disconnectWallet : connectWallet}
+            onClick={disconnectWallet}
             className="rounded-full bg-mint px-4 py-2 text-sm font-semibold text-ink transition hover:bg-white"
           >
-            {address ? "Disconnect" : "Connect Freighter"}
+            Disconnect
           </button>
         )}
       </div>
-      {address ? (
-        <div className="mt-4 rounded-2xl border border-mint/30 bg-ink/50 p-3 text-sm text-white">
-          Connected address: <span className="font-semibold">{truncateAddress(address)}</span>
+
+      {/* Wallet selector — shown when not connected */}
+      {!address && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {available.length === 0 ? (
+            <p className="text-sm text-sky/60">
+              No Stellar wallets detected.{" "}
+              <a
+                href="https://freighter.app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-mint underline decoration-mint/30 underline-offset-4 hover:decoration-mint"
+              >
+                Install Freighter
+              </a>
+            </p>
+          ) : (
+            available.map((wallet) => (
+              <button
+                key={wallet.id}
+                type="button"
+                disabled={connecting}
+                onClick={() => connectWallet(wallet.id)}
+                className="rounded-full border border-mint/40 px-4 py-2 text-sm font-semibold text-mint transition hover:bg-mint hover:text-ink disabled:opacity-50"
+              >
+                {connecting && activeWallet === wallet.id
+                  ? "Connecting…"
+                  : `Connect ${wallet.name}`}
+              </button>
+            ))
+          )}
         </div>
-      ) : null}
+      )}
+
+      {address && (
+        <div className="mt-4 rounded-2xl border border-mint/30 bg-ink/50 p-3 text-sm text-white">
+          Connected address:{" "}
+          <span className="font-semibold">{truncateAddress(address)}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/stellar.ts
+++ b/frontend/src/lib/stellar.ts
@@ -13,6 +13,10 @@ import { HORIZON_URL, STELLAR_NETWORK, NETWORK_PASSPHRASE } from "./config";
 import { CONTRACT_ID } from "./config";
 import { contractClient } from "./contract-client";
 
+// Re-export wallet utilities so callers can import from a single stellar module.
+export { getAvailableWallets, getWalletAdapter } from "./wallet-adapters";
+export type { WalletAdapter, WalletId } from "./wallet-adapters";
+
 export const stellarConfig = {
   horizonUrl: HORIZON_URL,
   stellarNetwork: STELLAR_NETWORK,

--- a/frontend/src/lib/wallet-adapters.ts
+++ b/frontend/src/lib/wallet-adapters.ts
@@ -1,0 +1,96 @@
+/**
+ * Wallet adapter pattern for Stellar wallets.
+ * Provides a consistent interface across Freighter, Albedo, and Lobstr.
+ */
+
+export type WalletId = "freighter" | "albedo" | "lobstr";
+
+export interface WalletAdapter {
+  id: WalletId;
+  name: string;
+  /** Returns true if the wallet is available in the current browser context. */
+  isAvailable(): boolean;
+  /** Request access and return the public key. Throws on denial or error. */
+  connect(): Promise<string>;
+}
+
+// ─── Freighter ────────────────────────────────────────────────────────────────
+
+const freighterAdapter: WalletAdapter = {
+  id: "freighter",
+  name: "Freighter",
+  isAvailable() {
+    if (typeof window === "undefined") return false;
+    // Freighter injects window.freighter
+    return !!(window as any).freighter;
+  },
+  async connect() {
+    const { getAddress, isAllowed, setAllowed } = await import(
+      "@stellar/freighter-api"
+    );
+    const access = await isAllowed();
+    if (!access.isAllowed) {
+      const permission = await setAllowed();
+      if (!permission.isAllowed) throw new Error("Freighter permission denied.");
+    }
+    const result = await getAddress();
+    if (result.error) throw new Error(result.error);
+    return result.address;
+  },
+};
+
+// ─── Albedo ───────────────────────────────────────────────────────────────────
+// Albedo injects window.albedo when its extension is installed.
+
+const albedoAdapter: WalletAdapter = {
+  id: "albedo",
+  name: "Albedo",
+  isAvailable() {
+    if (typeof window === "undefined") return false;
+    return !!(window as any).albedo;
+  },
+  async connect() {
+    const albedo = (window as any).albedo;
+    if (!albedo) throw new Error("Albedo extension not found.");
+    const result = await albedo.publicKey({ require_existing: false });
+    if (!result?.pubkey) throw new Error("Albedo did not return a public key.");
+    return result.pubkey;
+  },
+};
+
+// ─── Lobstr ───────────────────────────────────────────────────────────────────
+
+const lobstrAdapter: WalletAdapter = {
+  id: "lobstr",
+  name: "Lobstr",
+  isAvailable() {
+    if (typeof window === "undefined") return false;
+    // Lobstr Vault extension injects window.lobstr
+    return !!(window as any).lobstr;
+  },
+  async connect() {
+    const lobstr = (window as any).lobstr;
+    if (!lobstr) throw new Error("Lobstr extension not found.");
+    const result = await lobstr.getPublicKey();
+    if (!result) throw new Error("Lobstr did not return a public key.");
+    return result;
+  },
+};
+
+// ─── Registry ─────────────────────────────────────────────────────────────────
+
+const ALL_ADAPTERS: WalletAdapter[] = [
+  freighterAdapter,
+  albedoAdapter,
+  lobstrAdapter,
+];
+
+/** Returns adapters whose `isAvailable()` returns true. */
+export function getAvailableWallets(): WalletAdapter[] {
+  return ALL_ADAPTERS.filter((a) => a.isAvailable());
+}
+
+/** Returns the adapter for a given wallet id, or undefined. */
+export function getWalletAdapter(id: WalletId): WalletAdapter | undefined {
+  return ALL_ADAPTERS.find((a) => a.id === id);
+}

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,24 @@
+/** @type {import('@lhci/cli').LighthouseRcConfig} */
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: "npm run start",
+      startServerReadyPattern: "ready on",
+      url: ["http://localhost:3000"],
+      numberOfRuns: 1,
+    },
+    assert: {
+      assertions: {
+        "categories:performance": ["error", { minScore: 0.7 }],
+        "categories:accessibility": ["warn", { minScore: 0.8 }],
+        "first-contentful-paint": ["error", { maxNumericValue: 3000 }],
+        "largest-contentful-paint": ["error", { maxNumericValue: 4000 }],
+        "cumulative-layout-shift": ["error", { maxNumericValue: 0.25 }],
+        "total-blocking-time": ["warn", { maxNumericValue: 600 }],
+      },
+    },
+    upload: {
+      target: "temporary-public-storage",
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Closes #343 — Multi-wallet support
Closes #344 — Lighthouse CI for frontend performance

---

### #343 — Multiple wallet connections

**New file:** `frontend/src/lib/wallet-adapters.ts`
- `WalletAdapter` interface with a consistent `connect(): Promise<string>` API
- Adapters for **Freighter**, **Albedo** (`window.albedo`), and **Lobstr** (`window.lobstr`)
- `getAvailableWallets()` detects installed wallets at runtime; graceful fallback when none found

**Modified:** `frontend/src/components/wallet-connect.tsx`
- Dynamic wallet selector — renders a button per detected wallet
- Shows install prompt when no wallets are available
- Persists chosen wallet ID + address in localStorage for session restore

**Modified:** `frontend/src/lib/stellar.ts`
- Re-exports wallet utilities so callers can import from a single module

---

### #344 — Lighthouse CI

**New file:** `lighthouserc.js`
- Thresholds: performance ≥ 0.7, LCP ≤ 4s, FCP ≤ 3s, CLS ≤ 0.25, TBT warn at 600ms
- Uploads results to temporary public storage

**Modified:** `.github/workflows/frontend.yml`
- New `lighthouse` job runs on PRs only
- Fails CI on breached error-level assertions
- Uses `LHCI_GITHUB_APP_TOKEN` secret for PR comments

---

### Also fixed
- Pre-existing React hooks-rules violations in `profile-card.tsx` that were already breaking the build