### PR TITLE
Add API versioning with /v1 prefix

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -122,6 +122,16 @@ function createRateLimiters() {
   return { globalLimiter, writeLimiter, profileCreationLimiter, resendLimiter };
 }
 
+// ── API versioning constants ───────────────────────────────────────────
+const CURRENT_API_VERSION = "1";
+const SUPPORTED_API_VERSIONS = ["1"];
+
+// ── Shared pagination schema (used across multiple routes) ────────────
+const paginationSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
 function sendError(
   res: Response,
   status: number,
@@ -219,6 +229,16 @@ export function createApp(customLogger?: Logger) {
   app.use(pinoHttp({ logger: customLogger ?? logger }));
   app.use(globalLimiter);
 
+  // ── API-Version header on every response ──────────────────────────────
+  app.use((_req, res, next) => {
+    res.setHeader("API-Version", CURRENT_API_VERSION);
+    res.setHeader("X-Supported-API-Versions", SUPPORTED_API_VERSIONS.join(", "));
+    next();
+  });
+
+  // ── Build the versioned v1 router ─────────────────────────────────────
+  const v1Router = express.Router();
+
   /**
    * @openapi
    * /health:
@@ -232,7 +252,7 @@ export function createApp(customLogger?: Logger) {
    */
   // ── Health check with database connectivity ────────────────────────────
 
-  app.get("/health", async (req, res) => {
+  v1Router.get("/health", async (req, res) => {
     try {
       await prisma.$queryRaw`SELECT 1`;
       res.json({
@@ -302,7 +322,7 @@ export function createApp(customLogger?: Logger) {
    *                   example: Invalid wallet address
    */
   // Request a challenge nonce for wallet signature
-  app.post("/auth/challenge", (req, res) => {
+  v1Router.post("/auth/challenge", (req, res) => {
     const { walletAddress } = req.body;
 
     if (!walletAddress || !isValidStellarAddress(walletAddress)) {
@@ -350,7 +370,7 @@ export function createApp(customLogger?: Logger) {
    *       401:
    *         description: Invalid signature
    */
-  app.post("/auth/verify", async (req, res) => {
+  v1Router.post("/auth/verify", async (req, res) => {
     const parsed = verifySchema.safeParse(req.body);
     if (!parsed.success) {
       return sendError(res, 400, "Invalid request body");
@@ -473,7 +493,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.get("/profiles", async (req, res) => {
+  v1Router.get("/profiles", async (req, res) => {
     try {
       const pagination = paginationSchema.safeParse(req.query);
       if (!pagination.success) {
@@ -620,7 +640,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.get("/profiles/search", async (req, res) => {
+  v1Router.get("/profiles/search", async (req, res) => {
     const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
 
     if (!q) {
@@ -676,7 +696,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.get("/profiles/:username", async (req, res) => {
+  v1Router.get("/profiles/:username", async (req, res) => {
     try {
       const profile = await prisma.profile.findUnique({
         where: { username: req.params.username },
@@ -696,7 +716,7 @@ export function createApp(customLogger?: Logger) {
     }
   });
 
-  app.get("/profiles/:username/stats", async (req, res) => {
+  v1Router.get("/profiles/:username/stats", async (req, res) => {
     try {
       const profile = await prisma.profile.findUnique({
         where: { username: req.params.username },
@@ -850,7 +870,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.post("/profiles", requireAuth, profileCreationLimiter, writeLimiter, async (req, res) => {
+  v1Router.post("/profiles", requireAuth, profileCreationLimiter, writeLimiter, async (req, res) => {
     const parsed = createProfileSchema.safeParse(req.body);
 
     if (!parsed.success) {
@@ -1004,7 +1024,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.patch(
+  v1Router.patch(
     "/profiles/:username",
     requireAuth,
     writeLimiter,
@@ -1075,7 +1095,7 @@ export function createApp(customLogger?: Logger) {
 
   // ── Email verification (#275) ─────────────────────────────────────────
 
-  app.post("/profiles/:username/verify-email", async (req, res) => {
+  v1Router.post("/profiles/:username/verify-email", async (req, res) => {
     const { token } = req.body as { token?: unknown };
 
     if (!token || typeof token !== "string") {
@@ -1111,7 +1131,7 @@ export function createApp(customLogger?: Logger) {
     }
   });
 
-  app.post(
+  v1Router.post(
     "/profiles/:username/resend-verification-email",
     requireAuth,
     resendLimiter,
@@ -1221,7 +1241,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.patch(
+  v1Router.patch(
     "/profiles/:username/assets",
     requireAuth,
     writeLimiter,
@@ -1389,7 +1409,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.get("/profiles/:username/transactions", async (req, res) => {
+  v1Router.get("/profiles/:username/transactions", async (req, res) => {
     const pagination = paginationSchema.safeParse(req.query);
     if (!pagination.success) {
       return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
@@ -1453,7 +1473,7 @@ export function createApp(customLogger?: Logger) {
     return profile;
   }
 
-  app.post("/profiles/:username/webhooks", requireAuth, async (req, res) => {
+  v1Router.post("/profiles/:username/webhooks", requireAuth, async (req, res) => {
     const parsed = webhookCreateSchema.safeParse(req.body);
     if (!parsed.success) return sendError(res, 400, "Invalid URL — must be a valid HTTPS URL");
 
@@ -1468,7 +1488,7 @@ export function createApp(customLogger?: Logger) {
     return res.status(201).json({ id: webhook.id, url: webhook.url, secret });
   });
 
-  app.get("/profiles/:username/webhooks", requireAuth, async (req, res) => {
+  v1Router.get("/profiles/:username/webhooks", requireAuth, async (req, res) => {
     const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
     if (!profile) return;
 
@@ -1480,7 +1500,7 @@ export function createApp(customLogger?: Logger) {
     return res.json(webhooks);
   });
 
-  app.delete("/profiles/:username/webhooks/:id", requireAuth, async (req, res) => {
+  v1Router.delete("/profiles/:username/webhooks/:id", requireAuth, async (req, res) => {
     const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
     if (!profile) return;
 
@@ -1493,7 +1513,7 @@ export function createApp(customLogger?: Logger) {
     return res.status(204).send();
   });
 
-  app.get("/profiles/:username/webhooks/:id/deliveries", requireAuth, async (req, res) => {
+  v1Router.get("/profiles/:username/webhooks/:id/deliveries", requireAuth, async (req, res) => {
     const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
     if (!profile) return;
 
@@ -1518,7 +1538,7 @@ export function createApp(customLogger?: Logger) {
     return res.json({ deliveries, total, limit, offset });
   });
 
-  app.get("/profiles/:username/leaderboard", async (req, res) => {
+  v1Router.get("/profiles/:username/leaderboard", async (req, res) => {
     const pagination = paginationSchema.safeParse(req.query);
     if (!pagination.success) {
       return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
@@ -1594,7 +1614,7 @@ export function createApp(customLogger?: Logger) {
     return res.json(payload);
   });
 
-  app.get("/indexer/status", async (_req, res) => {
+  v1Router.get("/indexer/status", async (_req, res) => {
     const contractId =
       process.env.SOROBAN_CONTRACT_ID ??
       process.env.CONTRACT_ID ??
@@ -1692,7 +1712,7 @@ export function createApp(customLogger?: Logger) {
    *       500:
    *         description: Internal server error
    */
-  app.post(
+  v1Router.post(
     "/support-transactions",
     requireAuth,
     writeLimiter,
@@ -1888,7 +1908,7 @@ export function createApp(customLogger?: Logger) {
    *       404:
    *         description: Analytics not found
    */
-  app.get("/analytics/:campaignId", async (req, res) => {
+  v1Router.get("/analytics/:campaignId", async (req, res) => {
     const pagination = paginationSchema.safeParse(req.query);
     if (!pagination.success) {
       return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
@@ -1977,7 +1997,7 @@ export function createApp(customLogger?: Logger) {
    *       503:
    *         description: Avatar upload service unavailable
    */
-  app.post(
+  v1Router.post(
     "/profiles/:username/avatar",
     requireAuth,
     writeLimiter,
@@ -2037,7 +2057,7 @@ export function createApp(customLogger?: Logger) {
 
   // ── Multer error handler ───────────────────────────────────────────────
 
-  app.use(
+  v1Router.use(
     (
       err: unknown,
       req: express.Request,
@@ -2063,7 +2083,7 @@ export function createApp(customLogger?: Logger) {
     assetCode: z.string().default("XLM"),
   });
 
-  app.post("/profiles/:username/milestones", requireAuth, writeLimiter, async (req, res) => {
+  v1Router.post("/profiles/:username/milestones", requireAuth, writeLimiter, async (req, res) => {
     try {
       const username = req.params.username as string;
       const profile = await prisma.profile.findUnique({
@@ -2100,7 +2120,7 @@ export function createApp(customLogger?: Logger) {
     }
   });
 
-  app.get("/profiles/:username/milestones", async (req, res) => {
+  v1Router.get("/profiles/:username/milestones", async (req, res) => {
     try {
       const profile = await prisma.profile.findUnique({
         where: { username: req.params.username },
@@ -2121,7 +2141,7 @@ export function createApp(customLogger?: Logger) {
     }
   });
 
-  app.patch("/profiles/:username/milestones/:milestoneId", requireAuth, writeLimiter, async (req, res) => {
+  v1Router.patch("/profiles/:username/milestones/:milestoneId", requireAuth, writeLimiter, async (req, res) => {
     try {
       const username = req.params.username as string;
       const milestoneId = req.params.milestoneId as string;
@@ -2163,7 +2183,7 @@ export function createApp(customLogger?: Logger) {
     }
   });
 
-  app.delete("/profiles/:username/milestones/:milestoneId", requireAuth, writeLimiter, async (req, res) => {
+  v1Router.delete("/profiles/:username/milestones/:milestoneId", requireAuth, writeLimiter, async (req, res) => {
     try {
       const username = req.params.username as string;
       const milestoneId = req.params.milestoneId as string;
@@ -2201,7 +2221,7 @@ export function createApp(customLogger?: Logger) {
 
   // ── Supporters ─────────────────────────────────────────────────────────
 
-  app.get("/supporters/:address", async (req, res) => {
+  v1Router.get("/supporters/:address", async (req, res) => {
     try {
       const { address } = req.params;
 
@@ -2249,7 +2269,7 @@ export function createApp(customLogger?: Logger) {
 
   // ── Recurring Support ───────────────────────────────────────────────────
 
-  app.post("/recurring-support", requireAuth, writeLimiter, async (req, res) => {
+  v1Router.post("/recurring-support", requireAuth, writeLimiter, async (req, res) => {
     const { profileId, amount, assetCode, frequency } = req.body;
 
     if (!profileId || !amount || !frequency) {
@@ -2286,7 +2306,7 @@ export function createApp(customLogger?: Logger) {
     return res.status(201).json({ message: "Recurring support created" });
   });
 
-  app.get("/recurring-support", requireAuth, async (req, res) => {
+  v1Router.get("/recurring-support", requireAuth, async (req, res) => {
     const user = await prisma.user.findFirst({ where: { email: req.auth!.walletAddress } });
     if (!user) return sendError(res, 401, "User not found");
 
@@ -2299,7 +2319,7 @@ export function createApp(customLogger?: Logger) {
     return res.json(subscriptions);
   });
 
-  app.patch("/recurring-support/:id", requireAuth, async (req, res) => {
+  v1Router.patch("/recurring-support/:id", requireAuth, async (req, res) => {
     const { id } = req.params;
     const { status } = req.body;
 
@@ -2319,7 +2339,7 @@ export function createApp(customLogger?: Logger) {
     return res.json(updated);
   });
 
-  app.get("/recurring-support/:id", requireAuth, async (req, res) => {
+  v1Router.get("/recurring-support/:id", requireAuth, async (req, res) => {
     const { id } = req.params;
 
     const user = await prisma.user.findFirst({ where: { email: req.auth!.walletAddress } });
@@ -2336,7 +2356,7 @@ export function createApp(customLogger?: Logger) {
     return res.json(subscription);
   });
 
-  app.delete("/recurring-support/:id", requireAuth, async (req, res) => {
+  v1Router.delete("/recurring-support/:id", requireAuth, async (req, res) => {
     const { id } = req.params;
 
     const user = await prisma.user.findFirst({ where: { email: req.auth!.walletAddress } });
@@ -2351,7 +2371,7 @@ export function createApp(customLogger?: Logger) {
     return res.status(204).send();
   });
 
-  app.get("/profiles/:username/analytics/timeseries", async (req, res) => {
+  v1Router.get("/profiles/:username/analytics/timeseries", async (req, res) => {
     const { username } = req.params;
     const period = (req.query.period as string) || "daily";
     const assetCode = req.query.assetCode as string | undefined;
@@ -2433,7 +2453,7 @@ export function createApp(customLogger?: Logger) {
     return res.json(formatted);
   });
 
-  app.get("/profiles/:username/analytics/assets", async (req, res) => {
+  v1Router.get("/profiles/:username/analytics/assets", async (req, res) => {
     const { username } = req.params;
 
     const profile = await prisma.profile.findUnique({ where: { username } });
@@ -2459,6 +2479,23 @@ export function createApp(customLogger?: Logger) {
 
     return res.json({ breakdown, total: Number(total.toFixed(7)) });
   });
+
+  // ── Mount v1 router ───────────────────────────────────────────────────
+  // Primary versioned endpoint: /v1/...
+  app.use("/v1", v1Router);
+
+  // ── Deprecated unversioned aliases ────────────────────────────────────
+  // Keep old routes working but signal deprecation via headers.
+  // Clients should migrate to /v1/... endpoints.
+  const deprecationDate = "Sat, 01 Jan 2027 00:00:00 GMT";
+  const deprecationLink = '</v1>; rel="successor-version"';
+
+  app.use((req, res, next) => {
+    res.setHeader("Deprecation", deprecationDate);
+    res.setHeader("Link", deprecationLink);
+    res.setHeader("Sunset", deprecationDate);
+    next();
+  }, v1Router);
 
   return app;
 }

--- a/docs/API_VERSIONING.md
+++ b/docs/API_VERSIONING.md
@@ -1,0 +1,129 @@
+# API Versioning
+
+NovaSupport uses URL-based API versioning. All endpoints are available under `/v1/`.
+
+## Current Version
+
+**v1** — stable, actively maintained.
+
+## How to Use
+
+Prefix every request with `/v1/`:
+
+```
+GET  /v1/profiles
+POST /v1/auth/challenge
+GET  /v1/profiles/:username/stats
+```
+
+## Response Headers
+
+Every response includes versioning headers:
+
+| Header | Example | Description |
+|--------|---------|-------------|
+| `API-Version` | `1` | The current API version |
+| `X-Supported-API-Versions` | `1` | All supported versions |
+
+Deprecated (unversioned) routes also include:
+
+| Header | Description |
+|--------|-------------|
+| `Deprecation` | Date when the unversioned route will be removed |
+| `Sunset` | Same as Deprecation — RFC 8594 compliant |
+| `Link` | Points to the successor `/v1` route |
+
+## Unversioned Routes (Deprecated)
+
+The original unversioned routes (e.g. `GET /profiles`) still work but are
+deprecated. They return the same responses as `/v1/` but include deprecation
+headers to signal that clients should migrate.
+
+**Unversioned routes will be removed on 2027-01-01.**
+
+## Endpoint Reference
+
+All endpoints below are available at both `/v1/<path>` and `/<path>` (deprecated).
+
+### Auth
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/auth/challenge` | Request a challenge nonce |
+| POST | `/v1/auth/verify` | Verify signature, receive JWT |
+
+### Profiles
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/profiles` | — | List profiles (paginated) |
+| GET | `/v1/profiles/search` | — | Search profiles |
+| POST | `/v1/profiles` | ✓ | Create profile |
+| GET | `/v1/profiles/:username` | — | Get profile |
+| PATCH | `/v1/profiles/:username` | ✓ | Update profile |
+| PATCH | `/v1/profiles/:username/assets` | ✓ | Replace accepted assets |
+| POST | `/v1/profiles/:username/avatar` | ✓ | Upload avatar |
+| GET | `/v1/profiles/:username/stats` | — | Profile statistics |
+| GET | `/v1/profiles/:username/transactions` | — | Transaction history |
+| GET | `/v1/profiles/:username/leaderboard` | — | Top supporters |
+| POST | `/v1/profiles/:username/verify-email` | — | Verify email token |
+| POST | `/v1/profiles/:username/resend-verification-email` | ✓ | Resend verification |
+
+### Milestones
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/profiles/:username/milestones` | — | List milestones |
+| POST | `/v1/profiles/:username/milestones` | ✓ | Create milestone |
+| PATCH | `/v1/profiles/:username/milestones/:id` | ✓ | Update milestone |
+| DELETE | `/v1/profiles/:username/milestones/:id` | ✓ | Delete milestone |
+
+### Webhooks
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/profiles/:username/webhooks` | ✓ | List webhooks |
+| POST | `/v1/profiles/:username/webhooks` | ✓ | Create webhook |
+| DELETE | `/v1/profiles/:username/webhooks/:id` | ✓ | Delete webhook |
+| GET | `/v1/profiles/:username/webhooks/:id/deliveries` | ✓ | Delivery history |
+
+### Analytics
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/analytics/:campaignId` | Campaign analytics |
+| GET | `/v1/profiles/:username/analytics/timeseries` | Time-series data |
+| GET | `/v1/profiles/:username/analytics/assets` | Asset breakdown |
+
+### Support Transactions
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/v1/support-transactions` | ✓ | Record a transaction |
+
+### Recurring Support
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/v1/recurring-support` | ✓ | List subscriptions |
+| POST | `/v1/recurring-support` | ✓ | Create subscription |
+| GET | `/v1/recurring-support/:id` | ✓ | Get subscription |
+| PATCH | `/v1/recurring-support/:id` | ✓ | Pause/cancel |
+| DELETE | `/v1/recurring-support/:id` | ✓ | Delete subscription |
+
+### Supporters
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/supporters/:address` | Supporter profile and history |
+
+### Utilities
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/health` | Health check |
+| GET | `/v1/indexer/status` | Indexer status |
+| GET | `/docs` | Swagger UI |
+| GET | `/docs.json` | OpenAPI spec |
+
+## Migration Guide
+
+Replace the base path in your client:
+
+```diff
+- const BASE = "https://api.novasupport.xyz"
++ const BASE = "https://api.novasupport.xyz/v1"
+```
+
+No request bodies, query parameters, or response shapes have changed in v1.


### PR DESCRIPTION
- Defined paginationSchema (was missing, caused 4 pre-existing TS errors)
- Added CURRENT_API_VERSION and SUPPORTED_API_VERSIONS constants
- Created v1Router (express.Router) — all endpoints registered on it
- Mounted v1Router at /v1 as the primary versioned path
- Kept unversioned routes as deprecated aliases via second mount
- Deprecated routes return Deprecation, Sunset, and Link headers (sunset: 2027-01-01)
- Added API-Version and X-Supported-API-Versions headers to every response
- Docs endpoints (/docs, /docs.json) remain on app directly (not versioned)
- Added docs/API_VERSIONING.md with full endpoint reference and migration guide
- Reduced pre-existing TS errors from 13 to 9 (fixed paginationSchema)

closes #477
