### PR TITLE
feat: add embed widget, Sentry error logging, RSS feed, and notification preferences

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.5.0",
+    "@sentry/node": "^8.0.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "@supabase/supabase-js": "^2.100.1",
     "@types/sanitize-html": "^2.16.1",

--- a/backend/prisma/migrations/20260527000000_add_notification_preferences/migration.sql
+++ b/backend/prisma/migrations/20260527000000_add_notification_preferences/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable: NotificationPreferences — granular email notification controls per profile (#475)
+CREATE TABLE "NotificationPreferences" (
+    "id" TEXT NOT NULL,
+    "profileId" TEXT NOT NULL,
+    "notifyOnSupport" BOOLEAN NOT NULL DEFAULT true,
+    "notifyOnMilestone" BOOLEAN NOT NULL DEFAULT true,
+    "weeklyDigest" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationPreferences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: one row per profile
+CREATE UNIQUE INDEX "NotificationPreferences_profileId_key" ON "NotificationPreferences"("profileId");
+
+-- AddForeignKey
+ALTER TABLE "NotificationPreferences" ADD CONSTRAINT "NotificationPreferences_profileId_fkey" FOREIGN KEY ("profileId") REFERENCES "Profile"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -42,9 +42,21 @@ model Profile {
   recurringSupports   RecurringSupport[]
   milestones          Milestone[]
   webhooks            Webhook[]
+  notificationPreferences NotificationPreferences?
 
   @@index([createdAt(sort: Desc)])
   @@index([ownerId])
+}
+
+model NotificationPreferences {
+  id                 String   @id @default(cuid())
+  profileId          String   @unique
+  notifyOnSupport    Boolean  @default(true)
+  notifyOnMilestone  Boolean  @default(true)
+  weeklyDigest       Boolean  @default(false)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+  profile            Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
 }
 
 model AcceptedAsset {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { StrKey, Horizon } from "@stellar/stellar-sdk";
 import swaggerJsdoc from "swagger-jsdoc";
 import swaggerUi from "swagger-ui-express";
+import * as Sentry from "@sentry/node";
 import { prisma } from "./db.js";
 import { Prisma } from "@prisma/client";
 import { logger } from "./logger.js";
@@ -227,6 +228,10 @@ export function createApp(customLogger?: Logger) {
   app.use(sanitizeBody);
   app.use(sanitizeQuery);
   app.use(pinoHttp({ logger: customLogger ?? logger }));
+  // Attach Sentry request/tracing breadcrumbs when DSN is configured
+  if (process.env.SENTRY_DSN) {
+    app.use(Sentry.expressErrorHandler());
+  }
   app.use(globalLimiter);
 
   // ── API-Version header on every response ──────────────────────────────
@@ -419,6 +424,11 @@ export function createApp(customLogger?: Logger) {
 
     // Sign JWT
     const token = signJWT(walletAddress, user.id);
+
+    // Attach wallet address as Sentry user context for session breadcrumbs
+    if (process.env.SENTRY_DSN) {
+      Sentry.setUser({ id: user.id, username: walletAddress });
+    }
 
     res.json({ token, walletAddress, userId: user.id });
   });
@@ -1182,6 +1192,67 @@ export function createApp(customLogger?: Logger) {
     },
   );
 
+  // ── Notification preferences (#475) ──────────────────────────────────
+
+  const notifPrefsSchema = z.object({
+    notifyOnSupport: z.boolean().optional(),
+    notifyOnMilestone: z.boolean().optional(),
+    weeklyDigest: z.boolean().optional(),
+  });
+
+  v1Router.get("/profiles/:username/notification-preferences", requireAuth, async (req, res) => {
+    const { username } = req.params;
+
+    const profile = await prisma.profile.findUnique({ where: { username } });
+    if (!profile) return sendError(res, 404, "Profile not found");
+
+    if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      return sendError(res, 403, "Forbidden: You do not own this profile");
+    }
+
+    const prefs = await prisma.notificationPreferences.findUnique({
+      where: { profileId: profile.id },
+    });
+
+    // Return defaults when no preferences row exists yet
+    return res.json(
+      prefs ?? {
+        notifyOnSupport: true,
+        notifyOnMilestone: true,
+        weeklyDigest: false,
+      },
+    );
+  });
+
+  v1Router.patch("/profiles/:username/notification-preferences", requireAuth, writeLimiter, async (req, res) => {
+    const { username } = req.params;
+
+    const parsed = notifPrefsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendError(res, 400, "Invalid request body");
+    }
+
+    const profile = await prisma.profile.findUnique({ where: { username } });
+    if (!profile) return sendError(res, 404, "Profile not found");
+
+    if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      return sendError(res, 403, "Forbidden: You do not own this profile");
+    }
+
+    const prefs = await prisma.notificationPreferences.upsert({
+      where: { profileId: profile.id },
+      update: parsed.data,
+      create: {
+        profileId: profile.id,
+        notifyOnSupport: parsed.data.notifyOnSupport ?? true,
+        notifyOnMilestone: parsed.data.notifyOnMilestone ?? true,
+        weeklyDigest: parsed.data.weeklyDigest ?? false,
+      },
+    });
+
+    return res.json(prefs);
+  });
+
   // ── Update accepted assets ────────────────────────────────────────────
 
   const updateAssetsSchema = z.object({
@@ -1794,15 +1865,20 @@ export function createApp(customLogger?: Logger) {
         throw error;
       }
 
-      // Notify creator (async, best-effort)
+      // Notify creator (async, best-effort) — respects NotificationPreferences
       (async () => {
         try {
           const recipientProfile = await prisma.profile.findUnique({
             where: { id: supportRecord.profileId },
-            include: { owner: true },
+            include: { owner: true, notificationPreferences: true },
           });
 
-          if (recipientProfile?.owner?.email) {
+          const notifyOnSupport =
+            recipientProfile?.notificationPreferences?.notifyOnSupport ??
+            recipientProfile?.notifyOnSupport ??
+            true;
+
+          if (recipientProfile?.owner?.email && notifyOnSupport) {
             sendSupportReceivedEmail({
               to: recipientProfile.owner.email,
               fromAddress: supportRecord.supporterAddress ?? "Anonymous",
@@ -1873,6 +1949,92 @@ export function createApp(customLogger?: Logger) {
       res.status(201).json(supportRecord);
     },
   );
+
+  // ── Profile RSS feed (#478) ───────────────────────────────────────────
+
+  v1Router.get("/profiles/:username/feed.xml", async (req, res) => {
+    const { username } = req.params;
+
+    const profile = await prisma.profile.findUnique({
+      where: { username },
+      include: { milestones: { where: { status: "reached" }, orderBy: { updatedAt: "desc" }, take: 10 } },
+    });
+
+    if (!profile) {
+      return sendError(res, 404, "Profile not found");
+    }
+
+    const transactions = await prisma.supportTransaction.findMany({
+      where: { profileId: profile.id, status: "SUCCESS" },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    });
+
+    const baseUrl = process.env.FRONTEND_URL ?? "https://novasupport.xyz";
+    const profileUrl = `${baseUrl}/profile/${username}`;
+    const feedUrl = `${req.protocol}://${req.get("host")}/v1/profiles/${username}/feed.xml`;
+    const now = new Date().toUTCString();
+
+    const escapeXml = (s: string) =>
+      s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+
+    const txItems = transactions.map((tx) => {
+      const truncated = tx.supporterAddress
+        ? `${tx.supporterAddress.slice(0, 4)}…${tx.supporterAddress.slice(-4)}`
+        : "Anonymous";
+      const title = `${truncated} supported with ${tx.amount} ${tx.assetCode}`;
+      const description = tx.message
+        ? `${escapeXml(title)} — "${escapeXml(tx.message)}"`
+        : escapeXml(title);
+      return `
+    <item>
+      <title>${escapeXml(title)}</title>
+      <description>${description}</description>
+      <link>${profileUrl}</link>
+      <guid isPermaLink="false">tx-${escapeXml(tx.txHash)}</guid>
+      <pubDate>${new Date(tx.createdAt).toUTCString()}</pubDate>
+      <category>Support</category>
+    </item>`;
+    });
+
+    const milestoneItems = profile.milestones.map((m) => {
+      const title = `Milestone reached: ${m.title}`;
+      const description = m.description
+        ? `${escapeXml(title)} — ${escapeXml(m.description)}`
+        : escapeXml(title);
+      return `
+    <item>
+      <title>${escapeXml(title)}</title>
+      <description>${description}</description>
+      <link>${profileUrl}</link>
+      <guid isPermaLink="false">milestone-${escapeXml(m.id)}</guid>
+      <pubDate>${new Date(m.updatedAt).toUTCString()}</pubDate>
+      <category>Milestone</category>
+    </item>`;
+    });
+
+    const allItems = [...txItems, ...milestoneItems]
+      .sort(() => 0)  // already ordered by recency from their respective queries
+      .join("\n");
+
+    const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(profile.displayName)} on NovaSupport</title>
+    <link>${profileUrl}</link>
+    <description>Recent support activity for ${escapeXml(profile.displayName)} on NovaSupport — Stellar-native creator support.</description>
+    <language>en-us</language>
+    <lastBuildDate>${now}</lastBuildDate>
+    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+    <generator>NovaSupport RSS</generator>
+    ${allItems}
+  </channel>
+</rss>`;
+
+    res.setHeader("Content-Type", "application/rss+xml; charset=utf-8");
+    res.setHeader("Cache-Control", "public, max-age=300");
+    res.send(feed);
+  });
 
   // ── Analytics ──────────────────────────────────────────────────────────
 
@@ -2496,6 +2658,30 @@ export function createApp(customLogger?: Logger) {
     res.setHeader("Sunset", deprecationDate);
     next();
   }, v1Router);
+
+  // ── Sentry global error handler ───────────────────────────────────────
+  // Must be registered after all routes and before any other error handlers
+  if (process.env.SENTRY_DSN) {
+    app.use(Sentry.expressErrorHandler({
+      shouldHandleError(error) {
+        // Capture 4xx client errors as well as 5xx server errors
+        return true;
+      },
+    }));
+  }
+
+  // Generic error fallback (logs + returns JSON)
+  app.use((err: Error, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    logger.error({ err, path: req.path, method: req.method }, "Unhandled application error");
+    if (process.env.SENTRY_DSN) {
+      Sentry.captureException(err, {
+        extra: { path: req.path, method: req.method },
+      });
+    }
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
 
   return app;
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,21 @@
 import "dotenv/config";
+import * as Sentry from "@sentry/node";
 import { logger } from "./logger.js";
+
+// Initialise Sentry as early as possible so all subsequent imports are instrumented
+if (process.env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV ?? "development",
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.2 : 1.0,
+    integrations: [
+      Sentry.prismaIntegration(),
+    ],
+  });
+  logger.info("Sentry error monitoring initialised");
+} else {
+  logger.warn("SENTRY_DSN not set — error monitoring is disabled");
+}
 
 const REQUIRED_ENV_VARS = ["DATABASE_URL", "DIRECT_URL"];
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -11,6 +11,19 @@ const nextConfig = {
     }
     return config;
   },
+  async headers() {
+    return [
+      {
+        // Allow cross-origin embedding of the embed widget pages
+        source: "/embed/:path*",
+        headers: [
+          { key: "Access-Control-Allow-Origin", value: "*" },
+          { key: "X-Frame-Options", value: "ALLOWALL" },
+          { key: "Content-Security-Policy", value: "frame-ancestors *" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { AppShell } from "@/components/app-shell";
-import { 
-  TrendingUp, Users, Wallet, Activity, 
+import { NotificationPreferences } from "@/components/notification-preferences";
+import {
+  TrendingUp, Users, Wallet, Activity,
   ArrowUpRight, ArrowDownRight, Plus, Edit2, Trash2, X
 } from "lucide-react";
 import { motion } from "framer-motion";
@@ -434,6 +435,9 @@ export default function DashboardPage() {
             </div>
           )}
         </section>
+
+        {/* Notification Preferences */}
+        {username && <NotificationPreferences username={username} />}
       </div>
     </AppShell>
   );

--- a/frontend/src/app/embed/[username]/page.tsx
+++ b/frontend/src/app/embed/[username]/page.tsx
@@ -1,0 +1,125 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { EmbedWidget, type EmbedTheme, type EmbedSize } from "@/components/embed-widget";
+import { API_BASE_URL } from "@/lib/config";
+
+type PageProps = {
+  params: { username: string };
+  searchParams: { theme?: string; size?: string };
+};
+
+type Profile = {
+  id: string;
+  username: string;
+  displayName: string;
+  bio: string;
+  avatarUrl?: string | null;
+  walletAddress: string;
+  acceptedAssets: Array<{ code: string; issuer?: string | null }>;
+};
+
+type ProfileStats = {
+  totalTransactions: number;
+  uniqueSupporters: number;
+  assetTotals: Array<{ assetCode: string; total: string }>;
+};
+
+type LeaderboardEntry = {
+  rank: number;
+  supporterAddress: string;
+  totalAmount: string;
+  assetCode: string;
+};
+
+async function getProfile(username: string): Promise<Profile | null> {
+  const res = await fetch(`${API_BASE_URL}/profiles/${username}`, {
+    next: { revalidate: 30 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+async function getStats(username: string): Promise<ProfileStats | null> {
+  const res = await fetch(`${API_BASE_URL}/profiles/${username}/stats`, {
+    next: { revalidate: 60 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+async function getLeaderboard(username: string): Promise<LeaderboardEntry[]> {
+  const res = await fetch(`${API_BASE_URL}/profiles/${username}/leaderboard`, {
+    next: { revalidate: 60 },
+  });
+  if (!res.ok) return [];
+  const body = await res.json() as { leaderboard?: LeaderboardEntry[] };
+  return (body.leaderboard ?? []).slice(0, 5);
+}
+
+export async function generateMetadata({ params }: { params: { username: string } }): Promise<Metadata> {
+  const profile = await getProfile(params.username);
+  if (!profile) return { title: "NovaSupport Embed" };
+  return {
+    title: `Support ${profile.displayName} — NovaSupport`,
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function EmbedPage({ params, searchParams }: PageProps) {
+  const profile = await getProfile(params.username);
+  if (!profile) notFound();
+
+  const [stats, leaderboard] = await Promise.all([
+    getStats(params.username),
+    getLeaderboard(params.username),
+  ]);
+
+  const theme: EmbedTheme =
+    searchParams.theme === "light" ? "light" : "dark";
+  const size: EmbedSize =
+    searchParams.size === "small"
+      ? "small"
+      : searchParams.size === "large"
+        ? "large"
+        : "medium";
+
+  const profileUrl = `https://novasupport.xyz/profile/${profile.username}`;
+
+  const recentSupporters = leaderboard.map((e) => ({
+    supporterAddress: e.supporterAddress,
+    totalAmount: e.totalAmount,
+    assetCode: e.assetCode,
+  }));
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex" />
+        <link rel="stylesheet" href="/embed.css" />
+      </head>
+      <body
+        style={{
+          margin: 0,
+          padding: 8,
+          background: "transparent",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+        }}
+      >
+        <EmbedWidget
+          username={profile.username}
+          displayName={profile.displayName}
+          bio={profile.bio}
+          avatarUrl={profile.avatarUrl}
+          acceptedAssets={profile.acceptedAssets}
+          stats={stats}
+          recentSupporters={recentSupporters}
+          theme={theme}
+          size={size}
+          profileUrl={profileUrl}
+        />
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -6,6 +6,7 @@ import { SupportPanel } from "@/components/support-panel";
 import { ProfileTabs } from "@/components/profile-tabs";
 import { QRCodeButton } from "@/components/qr-code-button";
 import { EmptyState } from "@/components/empty-state";
+import { EmbedCodeGenerator } from "@/components/embed-widget";
 import { API_BASE_URL } from "@/lib/config";
 
 type PageProps = {
@@ -102,6 +103,11 @@ export async function generateMetadata({
       description:
         profile.bio ?? `Support ${profile.displayName} on NovaSupport`,
       images: profile.avatarUrl ? [profile.avatarUrl] : [],
+    },
+    alternates: {
+      types: {
+        "application/rss+xml": `${API_BASE_URL}/profiles/${params.username}/feed.xml`,
+      },
     },
   };
 }
@@ -282,6 +288,10 @@ export default async function ProfilePage({ params }: PageProps) {
           
           <div className="px-2">
             <ProfileTabs username={profile.username} />
+          </div>
+
+          <div className="px-2">
+            <EmbedCodeGenerator username={profile.username} />
           </div>
         </div>
 

--- a/frontend/src/components/embed-widget.tsx
+++ b/frontend/src/components/embed-widget.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useState } from "react";
+
+type Asset = {
+  code: string;
+  issuer?: string | null;
+};
+
+type ProfileStats = {
+  totalTransactions: number;
+  uniqueSupporters: number;
+  assetTotals: Array<{ assetCode: string; total: string }>;
+};
+
+type Supporter = {
+  supporterAddress: string;
+  totalAmount: string;
+  assetCode: string;
+};
+
+export type EmbedTheme = "dark" | "light";
+export type EmbedSize = "small" | "medium" | "large";
+
+type EmbedWidgetProps = {
+  username: string;
+  displayName: string;
+  bio: string;
+  avatarUrl?: string | null;
+  acceptedAssets: Asset[];
+  stats?: ProfileStats | null;
+  recentSupporters?: Supporter[];
+  theme?: EmbedTheme;
+  size?: EmbedSize;
+  profileUrl: string;
+};
+
+const sizeClasses: Record<EmbedSize, string> = {
+  small: "max-w-xs text-xs",
+  medium: "max-w-sm text-sm",
+  large: "max-w-md text-sm",
+};
+
+const themeClasses: Record<EmbedTheme, { bg: string; border: string; text: string; muted: string; accent: string; btn: string }> = {
+  dark: {
+    bg: "bg-[#0a0a0f]",
+    border: "border-white/10",
+    text: "text-white",
+    muted: "text-white/50",
+    accent: "text-[#00e5b0]",
+    btn: "bg-[#00e5b0] text-[#0a0a0f] hover:bg-[#00c99a]",
+  },
+  light: {
+    bg: "bg-white",
+    border: "border-gray-200",
+    text: "text-gray-900",
+    muted: "text-gray-500",
+    accent: "text-indigo-600",
+    btn: "bg-indigo-600 text-white hover:bg-indigo-700",
+  },
+};
+
+export function EmbedWidget({
+  username,
+  displayName,
+  bio,
+  avatarUrl,
+  acceptedAssets,
+  stats,
+  recentSupporters = [],
+  theme = "dark",
+  size = "medium",
+  profileUrl,
+}: EmbedWidgetProps) {
+  const t = themeClasses[theme];
+  const s = sizeClasses[size];
+
+  const truncate = (addr: string) =>
+    addr.length > 10 ? `${addr.slice(0, 4)}…${addr.slice(-4)}` : addr;
+
+  return (
+    <div
+      className={`${s} ${t.bg} border ${t.border} rounded-2xl p-4 font-sans shadow-xl w-full`}
+      data-theme={theme}
+      data-size={size}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-3">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={displayName}
+            className="w-10 h-10 rounded-full object-cover flex-shrink-0"
+          />
+        ) : (
+          <div className="w-10 h-10 rounded-full bg-indigo-600 flex items-center justify-center text-white font-bold flex-shrink-0">
+            {displayName.slice(0, 2).toUpperCase()}
+          </div>
+        )}
+        <div className="min-w-0">
+          <p className={`font-semibold truncate ${t.text}`}>{displayName}</p>
+          <p className={`${t.muted} truncate`}>@{username}</p>
+        </div>
+      </div>
+
+      {/* Bio */}
+      {bio && (
+        <p className={`${t.muted} mb-3 line-clamp-2 leading-relaxed`}>{bio}</p>
+      )}
+
+      {/* Stats */}
+      {stats && (
+        <div className={`flex gap-4 mb-3 pb-3 border-b ${t.border}`}>
+          <div>
+            <p className={`${t.muted} uppercase tracking-wider`} style={{ fontSize: "0.6rem" }}>
+              Supporters
+            </p>
+            <p className={`font-bold ${t.text}`}>{stats.uniqueSupporters}</p>
+          </div>
+          <div>
+            <p className={`${t.muted} uppercase tracking-wider`} style={{ fontSize: "0.6rem" }}>
+              Transactions
+            </p>
+            <p className={`font-bold ${t.text}`}>{stats.totalTransactions}</p>
+          </div>
+          {stats.assetTotals.slice(0, 1).map((a) => (
+            <div key={a.assetCode}>
+              <p className={`${t.muted} uppercase tracking-wider`} style={{ fontSize: "0.6rem" }}>
+                Total ({a.assetCode})
+              </p>
+              <p className={`font-bold ${t.accent}`}>
+                {parseFloat(a.total).toLocaleString()}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Recent supporters */}
+      {recentSupporters.length > 0 && (
+        <div className="mb-3">
+          <p className={`${t.muted} uppercase tracking-wider mb-1`} style={{ fontSize: "0.6rem" }}>
+            Recent Supporters
+          </p>
+          <div className="space-y-1">
+            {recentSupporters.slice(0, 3).map((s) => (
+              <div key={s.supporterAddress} className="flex items-center justify-between">
+                <span className={`font-mono ${t.muted}`}>{truncate(s.supporterAddress)}</span>
+                <span className={`font-semibold ${t.accent}`}>
+                  {s.totalAmount} {s.assetCode}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Accepted assets */}
+      {acceptedAssets.length > 0 && (
+        <div className={`flex flex-wrap gap-1 mb-3 pb-3 border-b ${t.border}`}>
+          {acceptedAssets.map((a) => (
+            <span
+              key={`${a.code}-${a.issuer ?? "native"}`}
+              className={`rounded-full border ${t.border} px-2 py-0.5 ${t.muted}`}
+              style={{ fontSize: "0.65rem" }}
+            >
+              {a.code}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* CTA */}
+      <a
+        href={profileUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`block w-full text-center rounded-xl px-3 py-2 font-semibold transition-colors ${t.btn}`}
+      >
+        Support {displayName}
+      </a>
+
+      {/* Powered by */}
+      <p className={`text-center mt-2 ${t.muted}`} style={{ fontSize: "0.6rem" }}>
+        Powered by{" "}
+        <a
+          href="https://novasupport.xyz"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={t.accent}
+        >
+          NovaSupport
+        </a>
+      </p>
+    </div>
+  );
+}
+
+type EmbedCodeGeneratorProps = {
+  username: string;
+};
+
+export function EmbedCodeGenerator({ username }: EmbedCodeGeneratorProps) {
+  const [theme, setTheme] = useState<EmbedTheme>("dark");
+  const [size, setSize] = useState<EmbedSize>("medium");
+  const [copied, setCopied] = useState(false);
+
+  const baseUrl =
+    typeof window !== "undefined"
+      ? window.location.origin
+      : "https://novasupport.xyz";
+
+  const iframeUrl = `${baseUrl}/embed/${username}?theme=${theme}&size=${size}`;
+  const embedCode = `<iframe
+  src="${iframeUrl}"
+  width="${size === "small" ? 320 : size === "medium" ? 380 : 448}"
+  height="320"
+  frameborder="0"
+  scrolling="no"
+  style="border:none;border-radius:1rem;overflow:hidden;"
+  title="Support ${username} on NovaSupport"
+></iframe>`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(embedCode);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // fallback for older browsers
+      const ta = document.createElement("textarea");
+      ta.value = embedCode;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/5 p-6 space-y-4">
+      <h3 className="text-sm font-semibold text-white uppercase tracking-widest">
+        Embed on Your Website
+      </h3>
+
+      <div className="flex flex-wrap gap-4">
+        <div>
+          <label className="text-xs text-sky/60 uppercase tracking-wider block mb-1">
+            Theme
+          </label>
+          <div className="flex gap-2">
+            {(["dark", "light"] as EmbedTheme[]).map((t) => (
+              <button
+                key={t}
+                onClick={() => setTheme(t)}
+                className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                  theme === t
+                    ? "border-mint text-mint bg-mint/10"
+                    : "border-white/10 text-sky/60 hover:border-white/30"
+                }`}
+              >
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="text-xs text-sky/60 uppercase tracking-wider block mb-1">
+            Size
+          </label>
+          <div className="flex gap-2">
+            {(["small", "medium", "large"] as EmbedSize[]).map((s) => (
+              <button
+                key={s}
+                onClick={() => setSize(s)}
+                className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                  size === s
+                    ? "border-mint text-mint bg-mint/10"
+                    : "border-white/10 text-sky/60 hover:border-white/30"
+                }`}
+              >
+                {s.charAt(0).toUpperCase() + s.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="relative">
+        <pre className="rounded-xl border border-white/10 bg-black/40 p-4 text-xs text-sky/80 overflow-x-auto whitespace-pre-wrap break-all">
+          {embedCode}
+        </pre>
+        <button
+          onClick={handleCopy}
+          className="absolute top-2 right-2 rounded-lg border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium text-white hover:bg-white/10 transition-colors"
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/notification-preferences.tsx
+++ b/frontend/src/components/notification-preferences.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+
+type Prefs = {
+  notifyOnSupport: boolean;
+  notifyOnMilestone: boolean;
+  weeklyDigest: boolean;
+};
+
+type Props = {
+  username: string;
+};
+
+export function NotificationPreferences({ username }: Props) {
+  const [prefs, setPrefs] = useState<Prefs>({
+    notifyOnSupport: true,
+    notifyOnMilestone: true,
+    weeklyDigest: false,
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = localStorage.getItem("authToken");
+    if (!token) {
+      setLoading(false);
+      return;
+    }
+
+    fetch(`${API_BASE_URL}/profiles/${username}/notification-preferences`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) setPrefs(data);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [username]);
+
+  const handleToggle = (key: keyof Prefs) => {
+    setPrefs((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const token = localStorage.getItem("authToken");
+      const res = await fetch(
+        `${API_BASE_URL}/profiles/${username}/notification-preferences`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify(prefs),
+        },
+      );
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to save preferences");
+      }
+
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2500);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) return null;
+
+  const toggleClass = (on: boolean) =>
+    `relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${
+      on ? "bg-[#00e5b0]" : "bg-white/10"
+    }`;
+
+  const knobClass = (on: boolean) =>
+    `pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-md transition duration-200 ${
+      on ? "translate-x-4" : "translate-x-0"
+    }`;
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-6 space-y-4">
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-white/60">
+        Notification Preferences
+      </h2>
+
+      <div className="space-y-3">
+        <PreferenceRow
+          label="New support received"
+          description="Get an email when someone sends you support."
+          checked={prefs.notifyOnSupport}
+          onToggle={() => handleToggle("notifyOnSupport")}
+          toggleClass={toggleClass}
+          knobClass={knobClass}
+        />
+        <PreferenceRow
+          label="Milestone reached"
+          description="Get an email when a funding goal is completed."
+          checked={prefs.notifyOnMilestone}
+          onToggle={() => handleToggle("notifyOnMilestone")}
+          toggleClass={toggleClass}
+          knobClass={knobClass}
+        />
+        <PreferenceRow
+          label="Weekly digest"
+          description="Receive a weekly summary of your support activity."
+          checked={prefs.weeklyDigest}
+          onToggle={() => handleToggle("weeklyDigest")}
+          toggleClass={toggleClass}
+          knobClass={knobClass}
+        />
+      </div>
+
+      {error && <p className="text-xs text-red-400">{error}</p>}
+
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        className="min-h-[44px] w-full rounded-xl bg-[#00e5b0] px-4 py-2 text-sm font-semibold text-black hover:bg-[#00c99a] transition-colors disabled:opacity-50"
+      >
+        {saving ? "Saving…" : saved ? "Saved!" : "Save preferences"}
+      </button>
+    </section>
+  );
+}
+
+function PreferenceRow({
+  label,
+  description,
+  checked,
+  onToggle,
+  toggleClass,
+  knobClass,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onToggle: () => void;
+  toggleClass: (on: boolean) => string;
+  knobClass: (on: boolean) => string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-xl border border-white/5 bg-white/[0.03] px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-white">{label}</p>
+        <p className="text-xs text-white/40 mt-0.5">{description}</p>
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={onToggle}
+        className={toggleClass(checked)}
+      >
+        <span className={knobClass(checked)} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements four community-requested features to improve creator tooling, observability, and discoverability:

- **#480 — Profile embed widget**: Creators can embed a live support stats card on any external website using a customisable `<iframe>`. The card supports dark/light themes and three sizes (small/medium/large). An \"Embed on Your Website\" code generator is added directly to each profile page so creators can copy the snippet immediately. CORS headers are configured in `next.config.mjs` so the embed page can be loaded cross-origin.

- **#479 — Sentry error monitoring**: `@sentry/node` is added as a dependency and initialised in `src/index.ts` before the Express app import, ensuring all unhandled exceptions are captured from startup. A global Express error handler is registered in `src/app.ts` so 4xx/5xx errors are sent to Sentry with request path and method as extra context. Wallet address is attached as the Sentry user context on successful authentication. The integration is gracefully skipped when `SENTRY_DSN` is not set.

- **#478 — Profile RSS 2.0 feed**: A new `GET /v1/profiles/:username/feed.xml` endpoint returns a standards-compliant RSS 2.0 feed containing the 20 most recent successful support transactions and the 10 most recently reached milestones. The feed includes proper `<atom:link>` self-reference and a `Cache-Control` header. RSS autodiscovery metadata is wired into the profile page `<head>` via Next.js `alternates`.

- **#475 — Granular notification preferences**: A new `NotificationPreferences` Prisma model (one-to-one with `Profile`) stores per-profile toggles: `notifyOnSupport`, `notifyOnMilestone`, and `weeklyDigest`. A database migration is included. `GET` and `PATCH /v1/profiles/:username/notification-preferences` endpoints let authenticated profile owners read and update their preferences. The existing email dispatch in `app.ts` now checks `notifyOnSupport` before sending, falling back to the legacy `Profile.notifyOnSupport` field for backwards compatibility. A toggle UI is added to the creator dashboard.

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/embed-widget.tsx` | New — `EmbedWidget` display component + `EmbedCodeGenerator` |
| `frontend/src/app/embed/[username]/page.tsx` | New — minimal embed page (no header/footer) |
| `frontend/next.config.mjs` | CORS headers for `/embed/*` routes |
| `frontend/src/app/profile/[username]/page.tsx` | Add `EmbedCodeGenerator` + RSS autodiscovery metadata |
| `frontend/src/components/notification-preferences.tsx` | New — toggle UI for notification settings |
| `frontend/src/app/dashboard/page.tsx` | Mount `NotificationPreferences` in creator dashboard |
| `backend/package.json` | Add `@sentry/node` dependency |
| `backend/src/index.ts` | Initialise Sentry SDK at startup |
| `backend/src/app.ts` | Sentry import + error handler; RSS endpoint; notification-preferences GET/PATCH endpoints; email respects preferences |
| `backend/prisma/schema.prisma` | Add `NotificationPreferences` model |
| `backend/prisma/migrations/20260527000000_add_notification_preferences/migration.sql` | New migration |

## Test plan

- [ ] `GET /v1/profiles/:username/feed.xml` returns valid RSS 2.0 XML with transactions and milestones
- [ ] Embed page renders at `/embed/:username?theme=dark&size=medium` without header/footer
- [ ] Embed page renders at `/embed/:username?theme=light&size=small`
- [ ] `<iframe>` can be loaded from a different origin (CORS)
- [ ] `EmbedCodeGenerator` snippet on profile page copies correct `<iframe>` code
- [ ] `GET /v1/profiles/:username/notification-preferences` returns defaults for a new profile
- [ ] `PATCH /v1/profiles/:username/notification-preferences` persists changes
- [ ] Unauthenticated PATCH returns 401/403
- [ ] Email is not sent when `notifyOnSupport` is set to `false`
- [ ] Sentry error handler wired: uncaught error in a route sends event to Sentry (requires `SENTRY_DSN` env var)
- [ ] Backend starts normally when `SENTRY_DSN` is absent (graceful no-op)
- [ ] Prisma migration applies cleanly: `prisma migrate deploy`
- [ ] Frontend build passes: `npm run build`
- [ ] Backend build passes: `npm run build`

Closes #480, Closes #479, Closes #478, Closes #475