### PR TITLE
test: add contract edge case tests for comprehensive coverage

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,50 @@ DIRECT_URL=postgresql://novasupport:novasupport@localhost:5432/novasupport
 # DIRECT_URL=postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-SUPABASE-PROJECT-REF].supabase.co:5432/postgres
 
 NEXT_PUBLIC_SUPABASE_URL=https://[YOUR-SUPABASE-PROJECT-REF].supabase.co
+# ──────────────────────────────────────
+# CORS Configuration
+# ──────────────────────────────────────
+# ALLOWED_ORIGINS — Comma-separated list of origins permitted to make
+# cross-origin requests to the API. Requests from origins NOT in this list
+# will be rejected with a CORS error.
+#
+# FORMAT:
+#   ALLOWED_ORIGINS=<origin1>,<origin2>,...
+#   Each origin must include the protocol (http:// or https://).
+#   Port numbers are part of the origin — localhost:3000 ≠ localhost:4000.
+#   Trailing slashes and whitespace around commas are trimmed automatically.
+#
+# WILDCARD (*):
+#   The wildcard character (*) is NOT supported in this list. The value "*"
+#   is treated as a literal string and will NOT match all origins. To allow
+#   all origins (e.g. for a public read-only API), set ALLOWED_ORIGINS to
+#   a single asterisk AND modify the CORS middleware in src/app.ts so that
+#   the "*" value triggers the wildcard behavior (Ref: https://github.com/expressjs/cors#configuration-options).
+#
+#   ⚠ SECURITY: Using a wildcard disables credentials (cookies, Authorization
+#   headers). Never combine credentials: true with origin: "*" — browsers
+#   will reject it. If your API uses cookies or Authorization headers, always
+#   list explicit origins.
+#
+# PREFLIGHT:
+#   Browsers send an OPTIONS preflight request before cross-origin requests
+#   with non-simple headers (e.g. Content-Type: application/json, Authorization).
+#   The cors middleware automatically responds to preflight with the appropriate
+#   Access-Control-Allow-* headers when the origin is allowed. No manual route
+#   setup is required.
+#
+# EXAMPLES:
+#   # Development only — frontend dev server
+#   ALLOWED_ORIGINS=http://localhost:3000
+#
+#   # Multiple environments
+#   ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+#
+#   # Production — explicit production domains only
+#   ALLOWED_ORIGINS=https://nova-support.vercel.app,https://app.novasupport.xyz
+#
+#   # Staging + production
+#   ALLOWED_ORIGINS=https://staging.novasupport.xyz,https://app.novasupport.xyz
 ALLOWED_ORIGINS=http://localhost:3000,https://nova-support.vercel.app
 
 SUPABASE_URL=https://your-project.supabase.co

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,129 @@
+# NovaSupport Backend
+
+Express + Prisma API service for profile and support metadata.
+
+## Quick Start
+
+```bash
+cp .env.example .env
+npm install
+npm run db:setup
+npm run dev
+```
+
+Runs on `http://localhost:4001` (configurable via `PORT`).
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in the required values. All available variables are documented with inline comments in `.env.example`.
+
+## CORS Configuration
+
+### `ALLOWED_ORIGINS`
+
+Controls which frontend origins are permitted to make cross-origin requests to the API.
+
+**Format:** Comma-separated list of full origins (protocol + host + optional port).
+
+```
+ALLOWED_ORIGINS=http://localhost:3000,https://nova-support.vercel.app
+```
+
+**Rules:**
+
+- Each origin must include the protocol (`http://` or `https://`).
+- Port numbers are significant — `localhost:3000` and `localhost:4001` are different origins.
+- Trailing slashes and whitespace around commas are trimmed automatically.
+- The wildcard `*` is **not** supported as a list member. See below.
+
+### Allowing All Origins (Wildcard)
+
+Setting `ALLOWED_ORIGINS=*` will **not** work out of the box — the current CORS middleware compares origins by exact string match. To allow all origins:
+
+1. Modify `src/app.ts` to detect `*` and pass `true` instead of using the origin callback.
+2. Be aware that browsers block credentialed requests (cookies, `Authorization` headers) when `Access-Control-Allow-Origin: *` is used. If your API relies on cookies or JWTs in Authorization headers, you **must** list explicit origins instead.
+
+### Examples
+
+| Environment | Value |
+|---|---|
+| Local dev (Next.js) | `ALLOWED_ORIGINS=http://localhost:3000` |
+| Local dev (Vite) | `ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173` |
+| Production | `ALLOWED_ORIGINS=https://nova-support.vercel.app` |
+| Staging + Prod | `ALLOWED_ORIGINS=https://staging.novasupport.xyz,https://app.novasupport.xyz` |
+
+### Security Implications
+
+- **Narrow allowlists are safer.** Only add origins you control. Adding `http://localhost:*` or arbitrary third-party URLs could expose your API to CSRF-style attacks.
+- **Credentials require exact origins.** If your frontend sends cookies or `Authorization` headers, the browser requires a specific (non-wildcard) `Access-Control-Allow-Origin` header. The current setup already enforces this by taking the `origin` from the request and echoing it back in the response.
+- **Requests without an origin** (e.g., `curl`, Postman, server-to-server calls) are always allowed — the CORS middleware passes them through.
+
+## Preflight Requests
+
+Browsers automatically send an `OPTIONS` preflight request before any cross-origin request that uses:
+
+- Methods other than `GET`, `HEAD`, or `POST`
+- Headers other than `Accept`, `Accept-Language`, `Content-Language`, or `Content-Type` with a safe value
+- `Content-Type` values like `application/json`
+- `Authorization` headers
+- Credentials mode
+
+The Express `cors` middleware handles preflight automatically. When a preflight arrives:
+
+1. The middleware checks the `Origin` header against `ALLOWED_ORIGINS`.
+2. If allowed, it responds with `200 OK` and the appropriate `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, and `Access-Control-Allow-Origin` headers.
+3. The browser then sends the actual request.
+
+No manual `OPTIONS` route handlers are needed.
+
+## Troubleshooting CORS Errors
+
+### Symptom: `Access to fetch at '...' from origin '...' has been blocked by CORS policy`
+
+This is the classic browser CORS error. Check:
+
+1. **Verify the origin is listed.** Open `.env` and confirm the exact origin the browser is sending (including protocol and port) is in `ALLOWED_ORIGINS`.
+2. **Check for typos.** Trailing slashes, missing `https://`, or wrong port numbers are common mistakes.
+3. **Restart the backend.** Changes to `.env` require a server restart.
+
+### Symptom: Works in Postman but not in the browser
+
+Postman does not enforce CORS. The browser does. This is normal and means your `ALLOWED_ORIGINS` likely does not include the frontend origin.
+
+### Symptom: Preflight `OPTIONS` request returns 403/500
+
+1. Check the backend logs — the CORS middleware throws `"Not allowed by CORS"` when the origin is not in the allowlist.
+2. Verify the preflight `OPTIONS` request is not hitting a rate limiter before the CORS middleware runs. Express middleware executes in the order it is registered. In `src/app.ts`, `cors()` is registered before `rateLimit`.
+
+### Symptom: `Authorization` header not sent (JWT missing on requests)
+
+Browsers strip sensitive headers on cross-origin requests unless the server explicitly allows credentials. Ensure:
+
+1. Your CORS configuration does not use a wildcard origin.
+2. The frontend includes `credentials: 'include'` or sets the `Authorization` header explicitly (both work with the current explicit-origin setup).
+
+### Quick health check
+
+```bash
+curl -I -X OPTIONS \
+  -H "Origin: http://localhost:3000" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: Content-Type" \
+  http://localhost:4001/
+```
+
+A `200 OK` response with `Access-Control-Allow-Origin: http://localhost:3000` means CORS is configured correctly for that origin. Replace the port if your backend runs on a different one.
+
+## Scripts
+
+| Script | Description |
+|---|---|
+| `npm run dev` | Start dev server with hot reload |
+| `npm run start` | Start production server |
+| `npm run build` | Compile TypeScript |
+| `npm run test` | Run test suite |
+| `npm run lint` | Lint with ESLint |
+| `npm run db:generate` | Generate Prisma client |
+| `npm run db:migrate` | Run pending migrations |
+| `npm run db:seed` | Seed the database |
+| `npm run db:setup` | Generate + migrate + seed |

--- a/contract/contracts/support_page/src/lib.rs
+++ b/contract/contracts/support_page/src/lib.rs
@@ -168,6 +168,9 @@ impl SupportPageContract {
         }
 
         // Validate message length (max 280 characters like Twitter)
+        if m.len() == 0 {
+            return Err(Error::EmptyMessage);
+        }
         if m.len() > 280 {
             return Err(Error::MessageTooLong);
         }
@@ -831,6 +834,169 @@ mod test {
         client.initialize(&admin);
 
         // Try to withdraw without any support received
+        client.withdraw(&recipient, &recipient, &asset, &1000_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")] // Error::EmptyMessage
+    fn support_with_empty_message() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let supporter = Address::generate(&e);
+        let recipient = Address::generate(&e);
+        let admin = Address::generate(&e);
+        let asset = e
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let token_admin = soroban_sdk::token::StellarAssetClient::new(&e, &asset);
+        token_admin.mint(&supporter, &10_000_i128);
+
+        client.initialize(&admin);
+
+        client.support(
+            &supporter,
+            &recipient,
+            &asset,
+            &1000_i128,
+            &String::from_str(&e, "XLM"),
+            &String::from_str(&e, ""),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #300)")] // Error::InsufficientBalance
+    fn support_with_insufficient_balance() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let supporter = Address::generate(&e);
+        let recipient = Address::generate(&e);
+        let admin = Address::generate(&e);
+        let asset = e
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let token_admin = soroban_sdk::token::StellarAssetClient::new(&e, &asset);
+        token_admin.mint(&supporter, &100_i128);
+
+        client.initialize(&admin);
+
+        client.support(
+            &supporter,
+            &recipient,
+            &asset,
+            &10_000_i128,
+            &String::from_str(&e, "XLM"),
+            &String::from_str(&e, "More than balance"),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")] // Error::ZeroAmount
+    fn withdraw_zero_amount() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let supporter = Address::generate(&e);
+        let recipient = Address::generate(&e);
+        let admin = Address::generate(&e);
+        let asset = e
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+
+        let token_admin = soroban_sdk::token::StellarAssetClient::new(&e, &asset);
+        token_admin.mint(&supporter, &10_000_i128);
+
+        client.initialize(&admin);
+        client.support(
+            &supporter,
+            &recipient,
+            &asset,
+            &5_000_i128,
+            &String::from_str(&e, "XLM"),
+            &String::from_str(&e, "Setup support"),
+        );
+
+        client.withdraw(&recipient, &recipient, &asset, &0_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")] // Error::NegativeAmount
+    fn withdraw_negative_amount() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let supporter = Address::generate(&e);
+        let recipient = Address::generate(&e);
+        let admin = Address::generate(&e);
+        let asset = e
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+
+        let token_admin = soroban_sdk::token::StellarAssetClient::new(&e, &asset);
+        token_admin.mint(&supporter, &10_000_i128);
+
+        client.initialize(&admin);
+        client.support(
+            &supporter,
+            &recipient,
+            &asset,
+            &5_000_i128,
+            &String::from_str(&e, "XLM"),
+            &String::from_str(&e, "Setup support"),
+        );
+
+        client.withdraw(&recipient, &recipient, &asset, &-1000_i128);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #101)")] // Error::NotAdmin
+    fn non_admin_cannot_unpause() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let admin = Address::generate(&e);
+        let intruder = Address::generate(&e);
+
+        client.initialize(&admin);
+        client.pause(&admin);
+        client.unpause(&intruder);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #201)")] // Error::ContractNotInitialized
+    fn pause_without_initialization() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let caller = Address::generate(&e);
+
+        client.pause(&caller);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #201)")] // Error::ContractNotInitialized
+    fn withdraw_without_initialization() {
+        let e = Env::default();
+        e.mock_all_auths();
+        let contract_id = e.register(SupportPageContract, ());
+        let client = SupportPageContractClient::new(&e, &contract_id);
+
+        let recipient = Address::generate(&e);
+        let asset = Address::generate(&e);
+
         client.withdraw(&recipient, &recipient, &asset, &1000_i128);
     }
 }


### PR DESCRIPTION
Closes #462

---

## Summary
- Added empty message validation in `support()` function (Error::EmptyMessage, #4)
- Added 7 new edge case tests covering previously untested code paths
- All error codes now have corresponding tests

## New Tests Added
| Test | Error Code | Description |
|------|-----------|-------------|
| `support_with_empty_message` | #4 EmptyMessage | Support with blank message must fail |
| `support_with_insufficient_balance` | #300 InsufficientBalance | Support amount exceeding supporter balance |
| `withdraw_zero_amount` | #2 ZeroAmount | Withdraw with zero amount must fail |
| `withdraw_negative_amount` | #3 NegativeAmount | Withdraw with negative amount must fail |
| `non_admin_cannot_unpause` | #101 NotAdmin | Only admin can unpause the contract |
| `pause_without_initialization` | #201 ContractNotInitialized | Cannot pause uninitialized contract |
| `withdraw_without_initialization` | #201 ContractNotInitialized | Cannot withdraw from uninitialized contract |

## Production Code Change
- Added `EmptyMessage` check in `support()` to enforce non-empty messages (error code was already defined but not enforced)