### PR TITLE
feat/fix: email verification UX, transaction modal tests, 409 duplicate handling tests

### DIFF
--- a/frontend/src/components/__tests__/transaction-result-modal.test.tsx
+++ b/frontend/src/components/__tests__/transaction-result-modal.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { TransactionResultModal } from "../transaction-result-modal";
+
+const TX_HASH = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab";
+
+vi.mock("@/lib/stellar", () => ({
+  stellarConfig: { horizonUrl: "https://horizon-testnet.stellar.org" },
+  withStellarRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+}));
+
+const defaultProps = {
+  txHash: TX_HASH,
+  amount: "5",
+  assetCode: "XLM",
+  recipientDisplayName: "Alice",
+  isOpen: true,
+  onClose: vi.fn(),
+};
+
+function mockHorizonResponse(status: number, body: object) {
+  vi.spyOn(global, "fetch").mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response);
+}
+
+describe("TransactionResultModal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders with Confirming status initially", () => {
+    render(<TransactionResultModal {...defaultProps} />);
+    expect(screen.getByText(/Support Sent!/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirming\.\.\./i)).toBeInTheDocument();
+  });
+
+  it("shows truncated tx hash", () => {
+    render(<TransactionResultModal {...defaultProps} />);
+    const truncated = `${TX_HASH.slice(0, 8)}...${TX_HASH.slice(-8)}`;
+    expect(screen.getByText(truncated)).toBeInTheDocument();
+  });
+
+  it("shows a link to Stellar Expert", () => {
+    render(<TransactionResultModal {...defaultProps} />);
+    const link = screen.getByRole("link", { name: /View on Explorer/i });
+    expect(link).toHaveAttribute(
+      "href",
+      `https://stellar.expert/explorer/testnet/tx/${TX_HASH}`,
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("transitions to Confirmed ✓ when Horizon returns successful: true", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ successful: true }),
+    } as Response);
+
+    render(<TransactionResultModal {...defaultProps} />);
+
+    await waitFor(
+      () => expect(screen.getByText(/Confirmed ✓/i)).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+  });
+
+  it("transitions to Finalized after confirmation", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ successful: true }),
+    } as Response);
+
+    render(<TransactionResultModal {...defaultProps} />);
+
+    await waitFor(() => expect(screen.getByText(/Confirmed ✓/i)).toBeInTheDocument(), {
+      timeout: 5000,
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Finalized/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows Failed status when Horizon reports unsuccessful: false", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ successful: false }),
+    } as Response);
+
+    render(<TransactionResultModal {...defaultProps} />);
+
+    await waitFor(
+      () => expect(screen.getByText(/Failed/i)).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+    expect(screen.getByText(/Transaction failed on-chain/i)).toBeInTheDocument();
+  });
+
+  it("shows error message when Horizon fetch throws", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValueOnce(new Error("Network error"));
+
+    render(<TransactionResultModal {...defaultProps} />);
+
+    await waitFor(
+      () => expect(screen.getByText(/Failed/i)).toBeInTheDocument(),
+      { timeout: 5000 },
+    );
+    expect(
+      screen.getByText(/Couldn't confirm transaction/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when isOpen is false", () => {
+    const { container } = render(
+      <TransactionResultModal {...defaultProps} isOpen={false} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when txHash is null", () => {
+    const { container } = render(
+      <TransactionResultModal {...defaultProps} txHash={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(<TransactionResultModal {...defaultProps} onClose={onClose} />);
+    const backdrop = document.querySelector(".absolute.inset-0") as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(<TransactionResultModal {...defaultProps} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the optional note when provided", () => {
+    render(
+      <TransactionResultModal
+        {...defaultProps}
+        note="Thank you for your support!"
+      />,
+    );
+    expect(screen.getByText("Thank you for your support!")).toBeInTheDocument();
+  });
+
+  it("does not render the note section when note is omitted", () => {
+    render(<TransactionResultModal {...defaultProps} note={undefined} />);
+    expect(
+      screen.queryByText("Thank you for your support!"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -50,6 +50,7 @@ export function ProfileCard({
   const [copied, setCopied] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const [resending, setResending] = useState(false);
+  const [resendSent, setResendSent] = useState(false);
   const { showToast } = useToast();
 
   const isValid = isValidStellarAddress(walletAddress);
@@ -70,7 +71,8 @@ export function ProfileCard({
       });
       const data = await res.json();
       if (res.ok) {
-        showToast("Verification email resent!", "success");
+        setResendSent(true);
+        showToast("Verification email sent! Check your inbox.", "success");
       } else {
         showToast(data.error || "Failed to resend email", "error");
       }
@@ -140,20 +142,32 @@ export function ProfileCard({
     <div className="space-y-4">
       {isOwner && !isVerified && (
         <div className="rounded-2xl border border-gold/30 bg-gold/5 p-4 flex items-center justify-between gap-4 animate-in fade-in slide-in-from-top-4 duration-500">
-          <div className="flex items-center gap-3">
-            <span className="text-xl">✉️</span>
-            <div>
-              <p className="text-sm font-semibold text-white">Verify your email address</p>
-              <p className="text-xs text-sky/70">Check your inbox to secure your profile and receive notifications.</p>
+          {resendSent ? (
+            <div className="flex items-center gap-3 w-full">
+              <span className="text-xl">📬</span>
+              <div>
+                <p className="text-sm font-semibold text-white">Check your email</p>
+                <p className="text-xs text-sky/70">We sent a new verification link to your inbox. It expires in 24 hours.</p>
+              </div>
             </div>
-          </div>
-          <button
-            onClick={handleResend}
-            disabled={resending}
-            className="text-xs font-bold text-gold hover:text-white transition-colors disabled:opacity-50"
-          >
-            {resending ? 'Sending...' : 'Resend link'}
-          </button>
+          ) : (
+            <>
+              <div className="flex items-center gap-3">
+                <span className="text-xl">✉️</span>
+                <div>
+                  <p className="text-sm font-semibold text-white">Verify your email address</p>
+                  <p className="text-xs text-sky/70">Check your inbox to secure your profile and receive notifications.</p>
+                </div>
+              </div>
+              <button
+                onClick={handleResend}
+                disabled={resending}
+                className="text-xs font-bold text-gold hover:text-white transition-colors disabled:opacity-50"
+              >
+                {resending ? 'Sending...' : 'Resend link'}
+              </button>
+            </>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/support-panel.test.tsx
+++ b/frontend/src/components/support-panel.test.tsx
@@ -212,4 +212,77 @@ describe('SupportPanel', () => {
       expect(showToast).toHaveBeenCalledWith('Recipient address copied!', 'success');
     });
   });
+
+  it('handles 409 duplicate transaction gracefully — shows success with existing hash', async () => {
+    const horizonHash = 'aabbccdd11223344aabbccdd11223344';
+    const existingHash = 'deadbeef12345678deadbeef12345678';
+
+    vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
+    vi.mocked(signTransaction).mockResolvedValue({
+      signedTxXdr: 'signed-xdr',
+      signerAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+    vi.mocked(horizonServer.submitTransaction).mockResolvedValue({
+      hash: horizonHash,
+    } as never);
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      headers: new Headers(),
+      json: async () => ({ existingTxHash: existingHash }),
+    } as Response);
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
+
+    await waitFor(
+      () => expect(screen.getByText(/Support Sent!/i)).toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+
+    expect(showToast).toHaveBeenCalledWith(
+      'This transaction was already recorded',
+      'success',
+    );
+
+    // The modal should display the existing hash, not the Horizon hash
+    expect(screen.getByText(`${existingHash.slice(0, 8)}...${existingHash.slice(-8)}`)).toBeInTheDocument();
+  });
+
+  it('does not show an error panel when backend returns 409', async () => {
+    vi.mocked(buildSupportIntent).mockResolvedValue('unsigned-xdr');
+    vi.mocked(signTransaction).mockResolvedValue({
+      signedTxXdr: 'signed-xdr',
+      signerAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+    vi.mocked(horizonServer.submitTransaction).mockResolvedValue({
+      hash: 'somehash1234567890abcdef12345678',
+    } as never);
+
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      headers: new Headers(),
+      json: async () => ({ existingTxHash: 'existinghash1234567890abcdef1234' }),
+    } as Response);
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() => expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Send Support/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole('button', { name: /Send Support/i }));
+
+    await waitFor(
+      () => expect(screen.getByText(/Support Sent!/i)).toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+
+    // No error panel should be shown
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes #438
Closes #439
Closes #443
Closes #444

## What changed

### #438 — Complete email verification flow (`frontend/src/components/profile-card.tsx`)
The backend template, resend endpoint, and rate limiting were already implemented. What was missing: after the owner clicks **Resend link**, the banner showed no confirmation — users couldn't tell whether the request succeeded.
- Added `resendSent` state; set to `true` on a successful resend API response
- The banner now transitions from *"Verify your email address + Resend link button"* to *"Check your email / We sent a new verification link to your inbox"* — making it unambiguous that the email was dispatched
- Toast message updated to **"Verification email sent! Check your inbox."**
- The existing verified badge (`✓` next to the handle) and the `isVerified` prop remain unchanged

### #439 — Webhook delivery persistence and retry (`backend/src/services/webhook-processor.ts`)
All acceptance criteria were already met:
- `WebhookDelivery` model in `prisma/schema.prisma` (persists `webhook_id`, `event_type`, `payload`, `status`, `attempt_count`, `next_retry_at`, `last_error`)
- `webhook-processor.ts`: `processPendingWebhookDeliveries()` polls for due deliveries every 10 s, attempts HTTP POST with HMAC signature, and applies exponential backoff (1 s → 10 s → 100 s) on failure; permanently marks `failed` after 3 attempts
- `startWebhookProcessor()` is called from `index.ts` on server start — retries survive restarts
- `GET /profiles/:username/webhooks/:id/deliveries` endpoint returns paginated delivery history

### #443 — Transaction status polling tests (`frontend/src/components/__tests__/transaction-result-modal.test.tsx`)
The polling logic in `TransactionResultModal` was already implemented. Added 11 tests:
- Initial **Confirming...** status on open
- Truncated hash display (`abcdef12...34567890`)
- Stellar Expert explorer link (`href` + `target="_blank"`)
- Transition **Confirming → Confirmed ✓** when Horizon returns `successful: true`
- Transition **Confirmed ✓ → Finalized** after 1 500 ms timeout
- **Failed** status + message when Horizon reports `successful: false`
- **Failed** status + message when fetch throws (network error)
- Renders nothing when `isOpen=false` or `txHash=null`
- `onClose` called on backdrop click and Escape key
- Note rendered when provided; absent when omitted

### #444 — Duplicate 409 handling tests (`frontend/src/components/support-panel.test.tsx`)
The `support-panel.tsx` 409 handler was already in place. Added 2 tests:
- **Graceful success on 409**: mocks Horizon submit + backend 409 response with `existingTxHash`; asserts the result modal opens, `showToast` is called with `"success"`, and the modal displays the *existing* hash (not the Horizon hash)
- **No error panel on 409**: confirms no `role="alert"` or `/error/i` text appears — the user sees success, not a confusing error

## Why
- Users who clicked "Resend link" had no visual feedback beyond a toast — the banner stayed unchanged, causing repeated clicks and confusion
- The 409 and polling behaviours had no automated test coverage; regressions could go undetected
- The webhook background worker was already written but had no accompanying PR linking it to the issue

## How to test
- **#438**: Log in as profile owner with unverified email → click "Resend link" → banner should switch to "Check your email" message
- **#439**: Create a webhook, trigger a support transaction, check `GET /profiles/:username/webhooks/:id/deliveries` for delivery records; stop the server mid-retry and confirm the delivery resumes on restart
- **#443**: `cd frontend && pnpm test __tests__/transaction-result-modal` — all 11 tests should pass
- **#444**: `cd frontend && pnpm test support-panel` — the two new 409 tests should pass alongside existing ones