### PR TITLE
feat: issuer filtering, recurring support CRUD, env validation & workflow fixes

### DIFF
--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "node:net";
 import pino from "pino";
 import { createApp } from "./app.js";
 import { prisma } from "./db.js";
+import { signJWT } from "./auth.js";
 import {
   sanitizeString,
   sanitizeObject,
@@ -679,6 +680,419 @@ async function main() {
     assert.deepEqual(query.tags, ["tag1", "tag2", "tag3"]);
     assert.equal(query.single, "value");
   });
+
+  // ── Recurring Support CRUD tests ──────────────────────────────────────
+
+  if (!hasDb) {
+    console.log("SKIP recurring-support CRUD tests (no DATABASE_URL)");
+  } else {
+    // Test 32: POST /recurring-support → creates a record and returns 201
+    await runTest("POST /recurring-support → creates record with 201", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let userId: string | undefined;
+      let profileId: string | undefined;
+
+      try {
+        // Create user whose email == walletAddress (matches requireAuth lookup)
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-test-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const res = await fetch(`${srv.baseUrl}/recurring-support`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            profileId,
+            amount: "10",
+            assetCode: "XLM",
+            frequency: "monthly",
+          }),
+        });
+
+        assert.equal(res.status, 201, `Expected 201, got ${res.status}`);
+        const body = await res.json() as { message: string };
+        assert.equal(body.message, "Recurring support created");
+      } finally {
+        await srv.close();
+        if (profileId) {
+          await prisma.recurringSupport.deleteMany({ where: { profileId } });
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+
+    // Test 33: POST /recurring-support → invalid frequency returns 400
+    await runTest("POST /recurring-support → invalid frequency returns 400", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let userId: string | undefined;
+      let profileId: string | undefined;
+
+      try {
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-freq-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Freq Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const res = await fetch(`${srv.baseUrl}/recurring-support`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            profileId,
+            amount: "10",
+            frequency: "daily", // invalid
+          }),
+        });
+
+        assert.equal(res.status, 400, `Expected 400, got ${res.status}`);
+      } finally {
+        await srv.close();
+        if (profileId) {
+          await prisma.recurringSupport.deleteMany({ where: { profileId } });
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+
+    // Test 34: GET /recurring-support/:id → returns the record
+    await runTest("GET /recurring-support/:id → returns record for owner", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let userId: string | undefined;
+      let profileId: string | undefined;
+      let recurringId: string | undefined;
+
+      try {
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-get-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Get Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const nextRunAt = new Date();
+        nextRunAt.setDate(nextRunAt.getDate() + 30);
+        const record = await prisma.recurringSupport.create({
+          data: {
+            supporterId: user.id,
+            profileId,
+            amount: "5",
+            assetCode: "XLM",
+            frequency: "monthly",
+            nextRunAt,
+          },
+        });
+        recurringId = record.id;
+
+        const res = await fetch(`${srv.baseUrl}/recurring-support/${recurringId}`, {
+          headers: { authorization: `Bearer ${token}` },
+        });
+
+        assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
+        const body = await res.json() as { id: string; frequency: string };
+        assert.equal(body.id, recurringId);
+        assert.equal(body.frequency, "monthly");
+      } finally {
+        await srv.close();
+        if (recurringId) await prisma.recurringSupport.deleteMany({ where: { id: recurringId } });
+        if (profileId) {
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+
+    // Test 35: PATCH /recurring-support/:id → updates frequency and recalculates nextRunAt
+    await runTest("PATCH /recurring-support/:id → updates frequency and amount", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let userId: string | undefined;
+      let profileId: string | undefined;
+      let recurringId: string | undefined;
+
+      try {
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-patch-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Patch Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const nextRunAt = new Date();
+        nextRunAt.setDate(nextRunAt.getDate() + 30);
+        const record = await prisma.recurringSupport.create({
+          data: {
+            supporterId: user.id,
+            profileId,
+            amount: "5",
+            assetCode: "XLM",
+            frequency: "monthly",
+            nextRunAt,
+          },
+        });
+        recurringId = record.id;
+
+        const res = await fetch(`${srv.baseUrl}/recurring-support/${recurringId}`, {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ frequency: "weekly", amount: "15" }),
+        });
+
+        assert.equal(res.status, 200, `Expected 200, got ${res.status}`);
+        const body = await res.json() as { frequency: string; amount: string; nextRunAt: string };
+        assert.equal(body.frequency, "weekly");
+        assert.equal(body.amount, "15");
+        // nextRunAt should be ~7 days from now, not 30
+        const newNextRun = new Date(body.nextRunAt);
+        const diffDays = (newNextRun.getTime() - Date.now()) / (1000 * 60 * 60 * 24);
+        assert.ok(diffDays < 10, `Expected nextRunAt within 10 days for weekly, got ${diffDays.toFixed(1)} days`);
+      } finally {
+        await srv.close();
+        if (recurringId) await prisma.recurringSupport.deleteMany({ where: { id: recurringId } });
+        if (profileId) {
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+
+    // Test 36: PATCH /recurring-support/:id → empty body returns 400
+    await runTest("PATCH /recurring-support/:id → empty body returns 400", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let userId: string | undefined;
+      let profileId: string | undefined;
+      let recurringId: string | undefined;
+
+      try {
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-empty-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Empty Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const nextRunAt = new Date();
+        nextRunAt.setDate(nextRunAt.getDate() + 7);
+        const record = await prisma.recurringSupport.create({
+          data: {
+            supporterId: user.id,
+            profileId,
+            amount: "5",
+            assetCode: "XLM",
+            frequency: "weekly",
+            nextRunAt,
+          },
+        });
+        recurringId = record.id;
+
+        const res = await fetch(`${srv.baseUrl}/recurring-support/${recurringId}`, {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({}),
+        });
+
+        assert.equal(res.status, 400, `Expected 400, got ${res.status}`);
+      } finally {
+        await srv.close();
+        if (recurringId) await prisma.recurringSupport.deleteMany({ where: { id: recurringId } });
+        if (profileId) {
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+
+    // Test 37: DELETE /recurring-support/:id → cancels and returns 204
+    await runTest("DELETE /recurring-support/:id → returns 204", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let userId: string | undefined;
+      let profileId: string | undefined;
+
+      try {
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-del-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Del Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const nextRunAt = new Date();
+        nextRunAt.setDate(nextRunAt.getDate() + 7);
+        const record = await prisma.recurringSupport.create({
+          data: {
+            supporterId: user.id,
+            profileId,
+            amount: "5",
+            assetCode: "XLM",
+            frequency: "weekly",
+            nextRunAt,
+          },
+        });
+
+        const res = await fetch(`${srv.baseUrl}/recurring-support/${record.id}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${token}` },
+        });
+
+        assert.equal(res.status, 204, `Expected 204, got ${res.status}`);
+
+        // Confirm it no longer exists
+        const check = await prisma.recurringSupport.findUnique({ where: { id: record.id } });
+        assert.equal(check, null, "Record should be deleted");
+      } finally {
+        await srv.close();
+        if (profileId) {
+          await prisma.recurringSupport.deleteMany({ where: { profileId } });
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+
+    // Test 38: GET /recurring-support/:id → 403 for non-owner
+    await runTest("GET /recurring-support/:id → 403 for non-owner", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      let ownerUserId: string | undefined;
+      let otherUserId: string | undefined;
+      let profileId: string | undefined;
+      let recurringId: string | undefined;
+
+      try {
+        const ownerWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const otherWallet = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+        const ownerUser = await prisma.user.create({ data: { email: ownerWallet } });
+        ownerUserId = ownerUser.id;
+        const otherUser = await prisma.user.create({ data: { email: otherWallet } });
+        otherUserId = otherUser.id;
+        const otherToken = signJWT(otherWallet, otherUser.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-403-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur 403 Test",
+            bio: "",
+            walletAddress: ownerWallet,
+            ownerId: ownerUser.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const nextRunAt = new Date();
+        nextRunAt.setDate(nextRunAt.getDate() + 30);
+        const record = await prisma.recurringSupport.create({
+          data: {
+            supporterId: ownerUser.id,
+            profileId,
+            amount: "5",
+            assetCode: "XLM",
+            frequency: "monthly",
+            nextRunAt,
+          },
+        });
+        recurringId = record.id;
+
+        // Other user tries to access owner's subscription
+        const res = await fetch(`${srv.baseUrl}/recurring-support/${recurringId}`, {
+          headers: { authorization: `Bearer ${otherToken}` },
+        });
+
+        assert.equal(res.status, 403, `Expected 403, got ${res.status}`);
+      } finally {
+        await srv.close();
+        if (recurringId) await prisma.recurringSupport.deleteMany({ where: { id: recurringId } });
+        if (profileId) {
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (ownerUserId) await prisma.user.deleteMany({ where: { id: ownerUserId } });
+        if (otherUserId) await prisma.user.deleteMany({ where: { id: otherUserId } });
+      }
+    });
+  }
 
   if (hasDb) await prisma.$disconnect();
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -727,6 +727,15 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *           type: string
    *           example: XLM
    *         description: Filter by accepted asset code (e.g., XLM, USDC)
+   *       - in: query
+   *         name: assetIssuer
+   *         schema:
+   *           type: string
+   *           example: GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3THOJ2E37CEGOEZWDSP
+   *         description: >
+   *           Filter by asset issuer address. Use together with `asset` to distinguish
+   *           different issuers of the same asset code (e.g., Circle USDC vs another USDC).
+   *           Omit or leave empty to return profiles accepting any issuer of the given asset.
    *     responses:
    *       200:
    *         description: List of profiles
@@ -3403,12 +3412,20 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     return res.json(subscriptions);
   });
 
-  v1Router.patch("/recurring-support/:id", requireAuth, async (req, res) => {
-    const { id } = req.params;
-    const { status } = req.body;
+  const patchRecurringSupportSchema = z.object({
+    status: z.enum(["active", "paused", "cancelled"]).optional(),
+    frequency: z.enum(["weekly", "monthly"]).optional(),
+    amount: z.string().min(1).optional(),
+  }).refine((data) => data.status || data.frequency || data.amount, {
+    message: "At least one of status, frequency, or amount is required",
+  });
 
-    if (!status || (status !== "paused" && status !== "cancelled")) {
-      return sendError(res, 400, "status must be 'paused' or 'cancelled'");
+  v1Router.patch("/recurring-support/:id", requireAuth, writeLimiter, async (req, res) => {
+    const { id } = req.params;
+
+    const parsed = patchRecurringSupportSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendError(res, 400, parsed.error.errors[0]?.message ?? "Invalid request body");
     }
 
     const user = await prisma.user.findFirst({ where: { email: req.auth!.walletAddress } });
@@ -3418,7 +3435,28 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     if (!subscription) return sendError(res, 404, "Recurring support not found");
     if (subscription.supporterId !== user.id) return sendError(res, 403, "Forbidden");
 
-    const updated = await prisma.recurringSupport.update({ where: { id: id as string }, data: { status } });
+    const { status, frequency, amount } = parsed.data;
+
+    // Recalculate nextRunAt when frequency changes
+    let nextRunAt: Date | undefined;
+    if (frequency) {
+      nextRunAt = new Date();
+      if (frequency === "weekly") {
+        nextRunAt.setDate(nextRunAt.getDate() + 7);
+      } else {
+        nextRunAt.setDate(nextRunAt.getDate() + 30);
+      }
+    }
+
+    const updated = await prisma.recurringSupport.update({
+      where: { id: id as string },
+      data: {
+        ...(status ? { status } : {}),
+        ...(frequency ? { frequency } : {}),
+        ...(amount ? { amount } : {}),
+        ...(nextRunAt ? { nextRunAt } : {}),
+      },
+    });
 
     return res.json(updated);
   });

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -171,7 +171,7 @@ export default function ExplorePage() {
                 <option value="">All Issuers</option>
                 {filteredIssuers.map((issuer) => (
                   <option key={issuer.issuer} value={issuer.issuer}>
-                    {issuer.issuer.slice(0, 8)}...
+                    {issuer.code} — {issuer.issuer.slice(0, 4)}…{issuer.issuer.slice(-4)}
                   </option>
                 ))}
               </select>
@@ -236,12 +236,22 @@ export default function ExplorePage() {
                     {profile.acceptedAssets.slice(0, 3).map((a, idx) => (
                       <span
                         key={idx}
-                        className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-mint/20 text-mint"
-                        title={a.issuer ? `Issuer: ${a.issuer}` : ""}
+                        className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-mint/20 text-mint"
+                        title={a.issuer ? `Issuer: ${a.issuer}` : a.code}
                       >
                         {a.code}
+                        {a.issuer && (
+                          <span className="text-mint/50 font-normal">
+                            {a.issuer.slice(0, 4)}…{a.issuer.slice(-4)}
+                          </span>
+                        )}
                       </span>
                     ))}
+                    {profile.acceptedAssets.length > 3 && (
+                      <span className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-white/10 text-sky/60">
+                        +{profile.acceptedAssets.length - 3}
+                      </span>
+                    )}
                   </div>
                 </Link>
               ))}


### PR DESCRIPTION
Closes #431

---

Closes #432

---

Closes #430

---

Closes #429

---

## Summary

This PR addresses 4 issues:

### 1. Explore page — Filter by asset issuer
- **Backend**: `GET /profiles` `assetIssuer` query param now documented in OpenAPI/Swagger
- **Frontend**: Profile cards show truncated issuer address inline on asset badges (e.g. `USDC GA5Z…WDSP`) — no longer just a hidden tooltip
- Issuer dropdown options now read `USDC — GA5Z…WDSP` for clear distinction between different USDC issuers
- Overflow badge (+N) shown when a profile accepts more than 3 assets

### 2. GitHub workflows — already using `pull_request`
Both `backend.yml` and `contract.yml` already use `pull_request` with the secure `ref` checkout ✅

### 3. Recurring support CRUD endpoints
- **`PATCH /recurring-support/:id`**: Extended to support updating `frequency` (weekly/monthly) and `amount` — previously only `status` was accepted
- Automatically recalculates `nextRunAt` (+7 or +30 days) when frequency changes
- Added missing `writeLimiter` middleware
- **7 new integration tests** (Tests 32–38): create, invalid frequency, get by id, patch frequency+amount, empty patch body, delete, 403 non-owner

### 4. Environment variable validation — already complete
`backend/src/index.ts` already validates `JWT_SECRET`, `SMTP_*`, `SUPABASE_*`, and `HORIZON_URL` ✅

## Files changed
- `frontend/src/app/explore/page.tsx`
- `backend/src/app.ts`
- `backend/src/app.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)