### PR TITLE
Feature/accessibility labels

### DIFF
--- a/frontend/src/app/dashboard/[campaignId]/page.tsx
+++ b/frontend/src/app/dashboard/[campaignId]/page.tsx
@@ -615,7 +615,7 @@ export default function DashboardPage() {
 
         {/* Recent Transactions */}
         <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
-          <div className="mb-6 flex items-center justify-between gap-4">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
             <h3 className="text-sm font-semibold uppercase tracking-widest text-steel font-mono">
               On-Chain Explorer Integration
             </h3>
@@ -637,8 +637,8 @@ export default function DashboardPage() {
               </button>
             )}
           </div>
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-sm text-sky/70">
+          <div className="overflow-x-auto -mx-6 px-6">
+            <table className="w-full min-w-[480px] text-left text-sm text-sky/70">
               <thead className="border-b border-white/10 text-[10px] uppercase tracking-widest text-steel">
                 <tr>
                   <th className="pb-4 pr-4">Type</th>
@@ -658,7 +658,7 @@ export default function DashboardPage() {
                         {item.type}
                       </span>
                     </td>
-                    <td className="py-4 pr-4 font-mono text-xs">{item.user}</td>
+                    <td className="py-4 pr-4 font-mono text-xs max-w-[120px] truncate">{item.user}</td>
                     <td className="py-4 pr-4 text-white font-medium">{item.asset}</td>
                     <td className="py-4 pr-4 text-white font-medium">{item.amount}</td>
                     <td className="py-4 pr-4 text-right tabular-nums">{item.age}</td>

--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -650,6 +650,7 @@ export function SupportPanel({
               <div
                 className="text-[10px] font-medium text-sky/50"
                 aria-live="polite"
+                aria-atomic="true"
               >
                 {isBalanceLoading ? (
                   <span className="animate-pulse">Fetching balance...</span>
@@ -813,6 +814,16 @@ export function SupportPanel({
         type="button"
         onClick={handleSendSupport}
         disabled={!isValidAmount || isProcessing || noPathFound || isOverBalance || !isAccountFunded}
+        aria-label={
+          isSubmitting
+            ? "Submitting to Stellar network"
+            : isSigning
+              ? "Waiting for Freighter signature"
+              : isFindingPath
+                ? "Finding best exchange path"
+                : `Send support to ${recipientDisplayName}`
+        }
+        aria-busy={isProcessing}
         className="mt-6 w-full rounded-full bg-mint px-5 py-3 text-sm font-semibold text-ink transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-mint flex items-center justify-center gap-2"
       >
         {isProcessing && (

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,11 +1,14 @@
+const DEFAULTS: Record<string, string> = {
+  NEXT_PUBLIC_HORIZON_URL: "https://horizon-testnet.stellar.org",
+  NEXT_PUBLIC_API_BASE_URL: "http://localhost:3001",
+};
+
 function requireEnv(key: string): string {
   const value = process.env[key];
   if (!value) {
-    // During build time, provide defaults to allow the build to complete
-    if (typeof window === 'undefined') {
-      console.warn(`Missing environment variable: ${key}. Using default value for build.`);
-      if (key === "NEXT_PUBLIC_HORIZON_URL") return "https://horizon-testnet.stellar.org";
-      if (key === "NEXT_PUBLIC_API_BASE_URL") return "http://localhost:3001";
+    if (DEFAULTS[key]) {
+      console.warn(`Missing environment variable: ${key}. Using default value.`);
+      return DEFAULTS[key];
     }
     throw new Error(
       `Missing required environment variable: ${key}. Check frontend/.env.example.`


### PR DESCRIPTION
## What does this PR do?
Accessibility, mobile responsiveness, and env config fixes

Accessibility (support-panel.tsx)
- Added aria-atomic="true" to the balance display so screen readers announce the full 
balance string as a unit when it updates
- Added aria-label and aria-busy to the submit button so its state ("Send support to 
Creator", "Submitting…", etc.) is announced correctly

Environment config fix (config.ts)
- Fixed a runtime crash where NEXT_PUBLIC_HORIZON_URL and NEXT_PUBLIC_API_BASE_URL threw 
on the client side because the server-only typeof window === 'undefined' guard prevented 
fallback defaults from applying in the browser. Defaults now apply in both environments.

Mobile responsiveness (dashboard/[campaignId]/page.tsx)
- Transactions section header now wraps on narrow screens (flex-wrap) so the title and CSV
button don't overflow
- Transactions table gets min-w-[480px] to scroll horizontally rather than squash columns,
with -mx-6 px-6 so the scroll area extends to card edges on mobile
- Supporter address cell truncates long wallet addresses (max-w-[120px] truncate) to 
prevent layout blowout
- Rate limit headers (standardHeaders: true) were configured on all limiters
- Pagination validation (limit 1–100, offset ≥0, 400 on invalid) was applied to 
all paginated endpoints via the shared paginationSchema
- dashboard/page.tsx is fully responsive with correct grid breakpoints and 44px 
touch targets

<!-- A clear 1-3 sentence summary of the change -->

## Related issue

Closes #440 
closes #437 
closes #442 
closes #441 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test

<!-- Step-by-step instructions for a reviewer to verify this works -->

1.
2.
3.

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [ ] My branch is up to date with main
- [ ] Linter passes (`npm run lint`)
- [ ] Tests pass (`npm test`) if applicable
- [ ] I have not committed `.env` files or secrets
