### PR TITLE
feat: add dedicated rate limiting to profile creation endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -179,14 +179,17 @@ function createRateLimiters() {
     },
   });
 
-  // Stricter limiter for profile creation: 3 per hour per IP (#276)
+  // Stricter limiter for profile creation: 3 per hour per IP (#316)
   const profileCreationLimiter = rateLimit({
     windowMs: 60 * 60 * 1000,
     limit: 3,
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: (req) => req.ip ?? "unknown",
-    message: { error: "Too many profiles created from this IP address. Please try again in an hour.", code: "RATE_LIMIT_EXCEEDED" },
+    message: {
+      error: "Too many profiles created from this IP address. You can create up to 3 profiles per hour. Please try again later.",
+      code: "PROFILE_CREATION_RATE_LIMIT_EXCEEDED",
+    },
   });
 
   const resendLimiter = rateLimit({

--- a/backend/src/rate-limit.test.ts
+++ b/backend/src/rate-limit.test.ts
@@ -308,6 +308,56 @@ async function testProperty5() {
   );
 }
 
+// ── Property 6: Profile creation limiter enforces 3-per-hour threshold ────
+// Feature: profile-creation-rate-limiting, Property 6: profile creation limiter
+//
+// POST /profiles must return 429 on the 4th request from the same IP within
+// an hour. Uses an invalid body so Zod rejects it (400) before Prisma is
+// called — the profileCreationLimiter runs before the handler and still
+// counts the request.
+//
+// Validates: Issue #316 acceptance criteria
+
+async function testProperty6() {
+  // fast-check part: first request to POST /profiles → non-429
+  await fc.assert(
+    fc.asyncProperty(
+      fc.constant(null),
+      async () => {
+        const srv = await startFreshServer();
+        try {
+          const res = await sendRequest(srv.baseUrl, "POST", "/profiles", { username: "x" });
+          assert.notEqual(res.status, 429, "First POST /profiles should not be 429");
+        } finally {
+          await srv.close();
+        }
+      }
+    ),
+    { numRuns: 10 }
+  );
+
+  // Boundary test: 4th POST /profiles must be 429
+  {
+    const srv = await startFreshServer();
+    try {
+      for (let i = 0; i < 3; i++) {
+        const res = await sendRequest(srv.baseUrl, "POST", "/profiles", { username: "x" });
+        assert.notEqual(res.status, 429, `Profile creation request ${i + 1} should not be 429`);
+      }
+      const over = await sendRequest(srv.baseUrl, "POST", "/profiles", { username: "x" });
+      assert.equal(over.status, 429, "4th POST /profiles should be 429");
+
+      // Verify the error body has the correct structure
+      const body = await over.json();
+      assert.equal(typeof body.error, "string", "429 body must have an error string");
+      assert.ok(body.error.length > 0, "error field must be non-empty");
+      assert.equal(body.code, "PROFILE_CREATION_RATE_LIMIT_EXCEEDED", "429 body must have correct code");
+    } finally {
+      await srv.close();
+    }
+  }
+}
+
 // ── Main ───────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -330,6 +380,10 @@ async function main() {
   await runTest(
     "Property 5: write requests count against the global limit (fast-check × 100)",
     testProperty5
+  );
+  await runTest(
+    "Property 6: profile creation limiter enforces 3-per-hour threshold (fast-check × 10 + boundary)",
+    testProperty6
   );
 }
 


### PR DESCRIPTION
- Update profileCreationLimiter comment to reference issue #316
- Improve error message to be more descriptive and user-friendly
- Add distinct error code PROFILE_CREATION_RATE_LIMIT_EXCEEDED
- Add Property 6 test: profile creation limiter enforces 3-per-hour threshold
- Boundary test verifies 4th POST /profiles returns 429
- Verify 429 response body has correct error structure and code
- Keep existing writeLimiter on other endpoints unchanged

Rate limiting configuration:
- Profile creation: 3 requests per hour per IP
- Window: 60 minutes (3,600,000ms)
- Error code: PROFILE_CREATION_RATE_LIMIT_EXCEEDED
- Other endpoints: unchanged (writeLimiter: 20/15min)

Closes #316

