### PR TITLE
feat(indexer): added multi-page drainage, backfill, and profile resol…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,3 +76,26 @@ HORIZON_URL=https://horizon-testnet.stellar.org
 # for the profile import endpoint. Generate at https://github.com/settings/tokens
 # (no scopes required for public profile reads).
 # GITHUB_TOKEN=ghp_your_token_here
+
+# Soroban Contract Event Indexer
+# ────────────────────────────────────────────────────────────────────────────
+# SOROBAN_CONTRACT_ID — Required to enable the contract event indexer.
+# Deploy your Soroban contract and paste its ID here:
+#   e.g. SOROBAN_CONTRACT_ID=CCJZK7QYZ4GXJ7X5J6ZQ3W4V5B6C7D8E9F0G1H2I
+# Also accepts CONTRACT_ID or NEXT_PUBLIC_CONTRACT_ID as fallbacks.
+# SOROBAN_CONTRACT_ID=
+#
+# SOROBAN_RPC_URL — Soroban RPC endpoint (default: https://soroban-testnet.stellar.org)
+# SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+#
+# INDEXER_NETWORK — Network label stored on each indexed transaction (default: TESTNET)
+# INDEXER_NETWORK=TESTNET
+#
+# INDEXER_START_LEDGER — Ledger to start backfilling from when no cursor exists.
+# Set to 1 (or your contract deployment ledger) to capture all historical events.
+# When unset, the indexer starts from the latest ledger and only captures new events.
+# INDEXER_START_LEDGER=1
+#
+# INDEXER_MAX_PAGES_PER_TICK — Maximum RPC pages consumed in a single poll cycle.
+# Higher values drain large backlogs faster. Lower values reduce RPC pressure. (default: 500)
+# INDEXER_MAX_PAGES_PER_TICK=500

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -107,6 +107,12 @@ const contractId =
   "";
 const sorobanRpcUrl =
   process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
+const indexerStartLedger = process.env.INDEXER_START_LEDGER
+  ? Number(process.env.INDEXER_START_LEDGER)
+  : undefined;
+const indexerMaxPagesPerTick = process.env.INDEXER_MAX_PAGES_PER_TICK
+  ? Number(process.env.INDEXER_MAX_PAGES_PER_TICK)
+  : undefined;
 
 const eventIndexer =
   contractId.trim().length > 0
@@ -115,6 +121,8 @@ const eventIndexer =
         rpcClient: createSorobanRpcClient(sorobanRpcUrl),
         network: indexerNetwork,
         contractId,
+        startLedger: indexerStartLedger,
+        maxPagesPerTick: indexerMaxPagesPerTick,
       })
     : null;
 

--- a/backend/src/services/event-indexer.test.ts
+++ b/backend/src/services/event-indexer.test.ts
@@ -1,4 +1,4 @@
-// Lightweight unit tests for the EventIndexer (#281).
+// Lightweight unit tests for the EventIndexer (#281 / #423).
 //
 // We don't have a Prisma test instance available in this PR, so the tests
 // drive the indexer with a hand-rolled mock that satisfies just the prisma
@@ -22,17 +22,37 @@ interface CursorRow {
   createdAt: Date;
 }
 
+interface ProfileRow {
+  id: string;
+  walletAddress: string;
+}
+
+interface UpsertCall {
+  txHash: string;
+  profileId: string;
+  amount: string;
+  assetCode: string;
+  recipientAddress: string;
+  supporterAddress: string | null;
+}
+
 function buildPrismaMock(): {
   prisma: any;
   cursors: CursorRow[];
+  profiles: ProfileRow[];
   txCalls: number;
   insertedHashes: string[];
   updatedHashes: string[];
+  profileLookups: number;
+  upsertCalls: UpsertCall[];
 } {
   const cursors: CursorRow[] = [];
+  const profiles: ProfileRow[] = [];
   const insertedHashes: string[] = [];
   const updatedHashes: string[] = [];
+  const upsertCalls: UpsertCall[] = [];
   let txCalls = 0;
+  let profileLookups = 0;
 
   const cursorClient = {
     findUnique: async (args: { where: { network_contractId: { network: string; contractId: string } } }) => {
@@ -69,8 +89,25 @@ function buildPrismaMock(): {
     },
   };
 
+  const profileClient = {
+    findMany: async (args: { where: { walletAddress: { in: string[] } } }) => {
+      profileLookups++;
+      return profiles.filter(
+        (p) => args.where.walletAddress.in.includes(p.walletAddress),
+      );
+    },
+  };
+
   const supportTxClient = {
     upsert: async (args: { where: { txHash: string }; create: any; update: any }) => {
+      upsertCalls.push({
+        txHash: args.where.txHash,
+        profileId: args.create.profileId ?? args.update.profileId,
+        amount: args.create.amount,
+        assetCode: args.create.assetCode,
+        recipientAddress: args.create.recipientAddress,
+        supporterAddress: args.create.supporterAddress,
+      });
       const existing = insertedHashes.includes(args.where.txHash);
       if (existing) {
         updatedHashes.push(args.where.txHash);
@@ -90,6 +127,7 @@ function buildPrismaMock(): {
   const prisma = {
     indexerCursor: cursorClient,
     supportTransaction: supportTxClient,
+    profile: profileClient,
     $transaction: async (cb: (tx: any) => Promise<unknown>) => {
       txCalls += 1;
       return cb({
@@ -102,11 +140,16 @@ function buildPrismaMock(): {
   return {
     prisma,
     cursors,
+    profiles,
     get txCalls() {
       return txCalls;
     },
+    get profileLookups() {
+      return profileLookups;
+    },
     insertedHashes,
     updatedHashes,
+    upsertCalls,
   };
 }
 
@@ -246,4 +289,160 @@ await test("EventIndexer.pollOnce reads pre-existing cursor before fetching", as
   });
   await indexer.pollOnce();
   assert.equal(receivedCursor, "200-5");
+});
+
+await test("EventIndexer.pollOnce resolves profileId from recipient address", async () => {
+  const mock = buildPrismaMock();
+  mock.profiles.push({
+    id: "profile-abc",
+    walletAddress: "GAAA",
+  });
+
+  const indexer = new EventIndexer({
+    prisma: mock.prisma,
+    rpcClient: rpc([
+      {
+        events: [
+          event({
+            txHash: "tx-pro-1",
+            pagingToken: "300-1",
+            recipientAddress: "GAAA",
+          }),
+        ],
+        nextPagingToken: "300-1",
+      },
+    ]),
+    network: "TESTNET",
+    contractId: "C123",
+  });
+
+  await indexer.pollOnce();
+  assert.equal(mock.upsertCalls.length, 1);
+  assert.equal(mock.upsertCalls[0]!.profileId, "profile-abc");
+  assert.equal(mock.profileLookups, 1);
+});
+
+await test("EventIndexer.pollOnce falls back to __orphan__ when no profile matches", async () => {
+  const mock = buildPrismaMock();
+
+  const indexer = new EventIndexer({
+    prisma: mock.prisma,
+    rpcClient: rpc([
+      {
+        events: [
+          event({
+            txHash: "tx-orphan-1",
+            pagingToken: "400-1",
+            recipientAddress: "GUNKNOWN",
+          }),
+        ],
+        nextPagingToken: "400-1",
+      },
+    ]),
+    network: "TESTNET",
+    contractId: "C123",
+  });
+
+  await indexer.pollOnce();
+  assert.equal(mock.upsertCalls.length, 1);
+  assert.equal(mock.upsertCalls[0]!.profileId, "__orphan__");
+});
+
+await test("EventIndexer.pollOnce advances cursor across sequential pages", async () => {
+  const mock = buildPrismaMock();
+  let callCount = 0;
+
+  const rpcClient: EventIndexerRpcClient = {
+    async fetchEvents({ cursor }) {
+      callCount++;
+      if (cursor === "") {
+        return {
+          events: [event({ txHash: "tx-p1", pagingToken: "500-1" })],
+          nextPagingToken: "500-1",
+        };
+      }
+      if (cursor === "500-1") {
+        return {
+          events: [event({ txHash: "tx-p2", pagingToken: "500-2", ledger: 101 })],
+          nextPagingToken: null,
+        };
+      }
+      return { events: [], nextPagingToken: null };
+    },
+  };
+
+  const indexer = new EventIndexer({
+    prisma: mock.prisma,
+    rpcClient,
+    network: "TESTNET",
+    contractId: "C123",
+  });
+
+  // First page
+  const page1 = await indexer.pollOnce();
+  assert.equal(page1.ingested, 1);
+  assert.equal(page1.nextCursor, "500-1");
+
+  // Second page — reads cursor from DB which was updated by page 1
+  const page2 = await indexer.pollOnce();
+  assert.equal(page2.ingested, 1);
+  assert.equal(page2.nextCursor, null);
+
+  assert.equal(mock.upsertCalls.length, 2);
+  assert.deepEqual(mock.insertedHashes, ["tx-p1", "tx-p2"]);
+  assert.equal(mock.cursors.length, 1);
+  assert.equal(mock.cursors[0]!.lastPagingToken, "500-2");
+});
+
+await test("EventIndexer passes startLedger to RPC client when cursor is empty", async () => {
+  let receivedStartLedger: number | undefined;
+  const rpcClient: EventIndexerRpcClient = {
+    async fetchEvents(args) {
+      receivedStartLedger = args.startLedger;
+      return { events: [], nextPagingToken: null };
+    },
+  };
+
+  const indexer = new EventIndexer({
+    prisma: buildPrismaMock().prisma,
+    rpcClient,
+    network: "TESTNET",
+    contractId: "C123",
+    startLedger: 42,
+  });
+
+  await indexer.pollOnce();
+  assert.equal(receivedStartLedger, 42);
+});
+
+await test("EventIndexer does NOT pass startLedger when cursor already exists", async () => {
+  const mock = buildPrismaMock();
+  mock.cursors.push({
+    network: "TESTNET",
+    contractId: "C123",
+    lastPagingToken: "600-5",
+    lastLedger: 600,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+  });
+
+  let receivedStartLedger: number | undefined;
+  const rpcClient: EventIndexerRpcClient = {
+    async fetchEvents(args) {
+      receivedStartLedger = args.startLedger;
+      return { events: [], nextPagingToken: null };
+    },
+  };
+
+  const indexer = new EventIndexer({
+    prisma: mock.prisma,
+    rpcClient,
+    network: "TESTNET",
+    contractId: "C123",
+    startLedger: 42,
+  });
+
+  await indexer.pollOnce();
+  // Once a cursor exists, startLedger must not be sent — cursor takes over.
+  assert.equal(receivedStartLedger, undefined);
 });

--- a/backend/src/services/event-indexer.ts
+++ b/backend/src/services/event-indexer.ts
@@ -1,4 +1,4 @@
-// #281: Contract event indexing service.
+// #281 / #423: Contract event indexing service.
 //
 // Polls Soroban RPC for `SupportEvent`s emitted by the configured contract
 // and persists them as `SupportTransaction` rows so the backend stays in
@@ -45,6 +45,8 @@ export interface EventIndexerRpcClient {
   fetchEvents(args: {
     contractId: string;
     cursor: string;
+    /** Ledger to start from when no cursor exists yet (backfill). */
+    startLedger?: number;
   }): Promise<RpcEventPage>;
 }
 
@@ -55,9 +57,20 @@ export interface EventIndexerOptions {
   contractId: string;
   /** Milliseconds between polls. Defaults to 10s. */
   pollIntervalMs?: number;
+  /**
+   * Ledger to start backfilling from when no cursor exists yet.
+   * Defaults to the latest ledger (no historical backfill).
+   */
+  startLedger?: number;
+  /**
+   * Maximum pages to consume in a single tick. Prevents the indexer
+   * from blocking on a massive backlog. Defaults to 500.
+   */
+  maxPagesPerTick?: number;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 10_000;
+const DEFAULT_MAX_PAGES_PER_TICK = 500;
 
 /**
  * Long-running event indexer. Construct it, call `.start()` from the worker
@@ -70,6 +83,8 @@ export class EventIndexer {
   private readonly network: string;
   private readonly contractId: string;
   private readonly pollIntervalMs: number;
+  private readonly startLedger: number | undefined;
+  private readonly maxPagesPerTick: number;
   private stopped = false;
   private timer: NodeJS.Timeout | null = null;
 
@@ -79,6 +94,8 @@ export class EventIndexer {
     this.network = options.network;
     this.contractId = options.contractId;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.startLedger = options.startLedger;
+    this.maxPagesPerTick = options.maxPagesPerTick ?? DEFAULT_MAX_PAGES_PER_TICK;
   }
 
   start(): void {
@@ -97,12 +114,17 @@ export class EventIndexer {
   /**
    * Process a single page of events. Returns the number of events ingested
    * so callers (and tests) can assert progress.
+   *
+   * When called with no stored cursor, the RPC client uses `startLedger`
+   * (if configured) to backfill historical events; otherwise it starts
+   * from the latest ledger.
    */
   async pollOnce(): Promise<{ ingested: number; nextCursor: string | null }> {
     const cursor = await this.readCursor();
     const page = await this.rpcClient.fetchEvents({
       contractId: this.contractId,
       cursor,
+      startLedger: cursor ? undefined : this.startLedger,
     });
 
     if (page.events.length === 0) {
@@ -118,9 +140,25 @@ export class EventIndexer {
     const lastEvent = page.events[page.events.length - 1]!;
     const nextCursor = page.nextPagingToken ?? lastEvent.pagingToken;
 
+    // Resolve recipient addresses to profile IDs so we can link
+    // on-chain events to the correct NovaSupport profiles.
+    const recipientAddresses = [
+      ...new Set(page.events.map((e) => e.recipientAddress)),
+    ];
+    const profiles = await this.prisma.profile.findMany({
+      where: { walletAddress: { in: recipientAddresses } },
+      select: { id: true, walletAddress: true },
+    });
+    const profileByAddress = new Map(
+      profiles.map((p) => [p.walletAddress, p.id]),
+    );
+
     let ingested = 0;
     await this.prisma.$transaction(async (tx) => {
       for (const event of page.events) {
+        const profileId =
+          profileByAddress.get(event.recipientAddress) ?? "__orphan__";
+
         // Use the contract event's tx hash as the natural idempotency key.
         // SupportTransaction.txHash has a unique index so a duplicate insert
         // (e.g. from re-processing the same range during recovery) is a no-op.
@@ -132,6 +170,7 @@ export class EventIndexer {
             assetIssuer: event.assetIssuer,
             recipientAddress: event.recipientAddress,
             supporterAddress: event.supporterAddress,
+            profileId,
             updatedAt: new Date(),
           },
           create: {
@@ -143,11 +182,7 @@ export class EventIndexer {
             recipientAddress: event.recipientAddress,
             stellarNetwork: this.network,
             message: event.message,
-            // The indexer doesn't yet know which Profile to attach the tx
-            // to without a recipient↔profile lookup; that's handled in a
-            // follow-up. For now we mark the row as orphaned so the
-            // resolver job can claim it.
-            profileId: "__orphan__",
+            profileId,
             status: "SUCCESS",
           },
         });
@@ -226,9 +261,21 @@ export class EventIndexer {
   private async tick(): Promise<void> {
     if (this.stopped) return;
     try {
-      const { ingested } = await this.pollOnce();
-      if (ingested > 0) {
-        logger.info({ ingested, contractId: this.contractId }, "indexed events");
+      let totalIngested = 0;
+      let pages = 0;
+      // Drain multiple pages per tick so large event histories (backfill)
+      // are processed quickly rather than one page every pollIntervalMs.
+      while (pages < this.maxPagesPerTick) {
+        const { ingested, nextCursor } = await this.pollOnce();
+        totalIngested += ingested;
+        pages++;
+        if (ingested === 0 || nextCursor === null) break;
+      }
+      if (totalIngested > 0) {
+        logger.info(
+          { ingested: totalIngested, pages, contractId: this.contractId },
+          "indexed events",
+        );
       }
     } finally {
       this.scheduleNextTick(this.pollIntervalMs);

--- a/backend/src/services/soroban-rpc-client.ts
+++ b/backend/src/services/soroban-rpc-client.ts
@@ -84,24 +84,40 @@ export function createSorobanRpcClient(
   pageSize = 100,
 ): EventIndexerRpcClient {
   return {
-    async fetchEvents({ contractId, cursor }): Promise<RpcEventPage> {
+    async fetchEvents({ contractId, cursor, startLedger }): Promise<RpcEventPage> {
+      // When no cursor exists yet, determine the start ledger:
+      //   - If the caller explicitly provides startLedger (backfill), use it.
+      //   - Otherwise fall back to the current latest ledger so the indexer
+      //     picks up only recent events (safe default).
+      const effectiveStartLedger =
+        cursor || startLedger === undefined
+          ? undefined
+          : startLedger;
+
+      const params: Record<string, unknown> = {
+        filters: [
+          {
+            type: "contract",
+            contractIds: [contractId],
+          },
+        ],
+        pagination: {
+          limit: pageSize,
+          ...(cursor ? { cursor } : {}),
+        },
+      };
+
+      if (effectiveStartLedger !== undefined) {
+        params.startLedger = effectiveStartLedger;
+      } else if (!cursor) {
+        params.startLedger = await getLatestLedger(rpcUrl);
+      }
+
       const requestBody: Record<string, unknown> = {
         jsonrpc: "2.0",
         id: randomUUID(),
         method: "getEvents",
-        params: {
-          filters: [
-            {
-              type: "contract",
-              contractIds: [contractId],
-            },
-          ],
-          pagination: {
-            limit: pageSize,
-            ...(cursor ? { cursor } : {}),
-          },
-          ...(cursor ? {} : { startLedger: await getLatestLedger(rpcUrl) }),
-        },
+        params,
       };
 
       const response = await fetch(rpcUrl, {


### PR DESCRIPTION
feat(indexer): added multi-page drainage, backfill, and profile resolution (#423)

## What does this PR do?
Implements the complete contract event indexing service for Soroban by adding multi-page drainage per poll cycle, historical backfill via `startLedger`, and proper profile resolution for indexed transactions. This keeps backend data fully in sync with onchain state.

## Related issue
Closes #423

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test
<!-- Step-by-step instructions for a reviewer to verify this works -->
1. Copy the new env vars from `.env.example` into your `.env` — set `INDEXER_START_LEDGER` to the contract deployment ledger and `INDEXER_MAX_PAGES_PER_TICK=500`
2. Start the backend with `npm run dev` and confirm the indexer logs show it polling Soroban RPC periodically
3. Emit a `SupportEvent` on the contract and verify a matching transaction row appears in the database with the correct `profileId` (not `__orphan__`)
4. Reset the DB cursor and restart — confirm the indexer backfills all historical events from `INDEXER_START_LEDGER` across multiple pages without stopping after one
5. Run `npm test` and confirm all 5 new event-indexer tests pass

## Checklist
- [x ] I have read the CONTRIBUTING guide
- [x ] My branch is up to date with main
- [x ] Linter passes (`npm run lint`)
- [x ] Tests pass (`npm test`) if applicable
- [x ] I have not committed `.env` files or secrets