### PR TITLE
feat(security): implement transaction verification against Horizon API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -39,6 +39,10 @@ import {
   validateUsername,
   validateUsernameWithTakenCheck,
 } from "./utils/username-validator.js";
+import {
+  verifyTransaction as verifyTransactionService,
+  type ExpectedTxDetails,
+} from "./services/verify-transaction.js";
 
 // Extend Express Request to include auth context
 declare global {
@@ -2120,68 +2124,23 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     supporterId: z.string().optional().nullable(),
   });
 
-  const verificationCache = new Map<string, { result: boolean; timestamp: number }>();
-  const VERIFICATION_CACHE_TTL = 60 * 60 * 1000;
-
   async function verifyTransaction(
     txHash: string,
     retries = 3,
     backoffMs = 1000,
-    req?: express.Request
+    req?: express.Request,
+    expected?: ExpectedTxDetails
   ): Promise<boolean | "error"> {
-    const cached = verificationCache.get(txHash);
-    if (cached && Date.now() - cached.timestamp < VERIFICATION_CACHE_TTL) {
-      return cached.result;
-    }
-
-    const verify = async () => {
-      for (let attempt = 1; attempt <= retries; attempt++) {
-        try {
-          const tx = await stellarServer.transactions().transaction(txHash).call();
-          const result = tx.successful === true;
-          
-          if (result) {
-            verificationCache.set(txHash, { result, timestamp: Date.now() });
-          }
-          
-          return result;
-        } catch (e: unknown) {
-          if (
-            e &&
-            typeof e === "object" &&
-            "response" in e &&
-            e.response &&
-            typeof e.response === "object" &&
-            "status" in e.response &&
-            e.response.status === 404
-          ) {
-            return false;
-          }
-
-          if (attempt < retries) {
-            const delay = backoffMs * Math.pow(2, attempt - 1);
-            const log = req?.log ?? logger;
-            log.warn(
-              { txHash, attempt, delay, err: e },
-              "Horizon verification failed, retrying"
-            );
-            await new Promise((resolve) => setTimeout(resolve, delay));
-          } else {
-            throw e;
-          }
-        }
-      }
-      return "error" as const;
-    };
-
     try {
-      return await horizonCircuitBreaker.execute(verify);
+      return await horizonCircuitBreaker.execute(() =>
+        verifyTransactionService(stellarServer, txHash, retries, backoffMs, expected)
+      );
     } catch (e: any) {
       const log = req?.log ?? logger;
       if (e.message === "Circuit breaker is OPEN") {
-        log.warn({ txHash }, "Horizon circuit breaker is OPEN, skipping call");
+        log.warn({ txHash }, "Horizon circuit breaker is OPEN, skipping verification");
       } else {
-        log.error({ txHash, err: e }, "Horizon error verifying transaction after retries");
+        log.error({ txHash, err: e }, "Horizon error verifying transaction");
       }
       return "error";
     }
@@ -2859,13 +2818,21 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return res.status(400).json({ error: flat });
       }
 
-      const verification = await verifyTransaction(parsed.data.txHash, 3, 1000, req);
+      const expectedDetails: ExpectedTxDetails = {
+        amount: parsed.data.amount,
+        recipientAddress: parsed.data.recipientAddress,
+        assetCode: parsed.data.assetCode,
+        assetIssuer: parsed.data.assetIssuer,
+      };
+
+      const verification = await verifyTransaction(parsed.data.txHash, 3, 1000, req, expectedDetails);
 
       if (verification === false) {
         return res
           .status(422)
           .json({
-            error: "Transaction hash not found or not successful on Horizon.",
+            error:
+              "Transaction not found, not successful, or payment details (amount/recipient/asset) do not match.",
           });
       }
 

--- a/backend/src/services/verify-transaction.ts
+++ b/backend/src/services/verify-transaction.ts
@@ -1,0 +1,148 @@
+import type { Horizon } from "@stellar/stellar-sdk";
+import { logger } from "../logger.js";
+
+export interface ExpectedTxDetails {
+  amount: string;
+  recipientAddress: string;
+  assetCode: string;
+  assetIssuer?: string | null;
+}
+
+// Module-level cache shared across all calls in the same process
+const verificationCache = new Map<string, { result: boolean; timestamp: number }>();
+export const VERIFICATION_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+export function clearVerificationCache(): void {
+  verificationCache.clear();
+}
+
+function makeCacheKey(txHash: string, expected?: ExpectedTxDetails): string {
+  if (!expected) return txHash;
+  return `${txHash}|${expected.recipientAddress}|${expected.amount}|${expected.assetCode}|${expected.assetIssuer ?? ""}`;
+}
+
+function isAssetMatch(
+  op: { asset_type: string; asset_code?: string; asset_issuer?: string },
+  assetCode: string,
+  assetIssuer?: string | null
+): boolean {
+  const wantNative = assetCode === "XLM" || assetCode === "native";
+  if (wantNative) return op.asset_type === "native";
+  return op.asset_code === assetCode && op.asset_issuer === (assetIssuer ?? undefined);
+}
+
+// Scan the transaction's operations for a payment that matches all expected details.
+// Supports both `payment` and `create_account` (XLM-only) operation types.
+async function validatePaymentDetails(
+  server: Horizon.Server,
+  txHash: string,
+  expected: ExpectedTxDetails
+): Promise<boolean> {
+  const ops = await server.operations().forTransaction(txHash).call();
+
+  for (const op of ops.records) {
+    if (op.type === "payment") {
+      const p = op as unknown as {
+        to: string;
+        amount: string;
+        asset_type: string;
+        asset_code?: string;
+        asset_issuer?: string;
+      };
+      if (
+        p.to === expected.recipientAddress &&
+        parseFloat(p.amount) === parseFloat(expected.amount) &&
+        isAssetMatch(p, expected.assetCode, expected.assetIssuer)
+      ) {
+        return true;
+      }
+    }
+
+    if (op.type === "create_account") {
+      const c = op as unknown as { account: string; starting_balance: string };
+      const wantNative = expected.assetCode === "XLM" || expected.assetCode === "native";
+      if (
+        wantNative &&
+        c.account === expected.recipientAddress &&
+        parseFloat(c.starting_balance) === parseFloat(expected.amount)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isHorizon404(e: unknown): boolean {
+  return (
+    e != null &&
+    typeof e === "object" &&
+    "response" in e &&
+    (e as { response: unknown }).response != null &&
+    typeof (e as { response: unknown }).response === "object" &&
+    "status" in ((e as { response: unknown }).response as object) &&
+    ((e as { response: { status: unknown } }).response.status as number) === 404
+  );
+}
+
+/**
+ * Verify a Stellar transaction against Horizon.
+ *
+ * @param server   - Horizon.Server instance to query (injectable for testing)
+ * @param txHash   - Transaction hash to verify
+ * @param retries  - Number of attempts before returning "error" (default 3)
+ * @param backoffMs - Base delay in ms; doubled on each retry (default 1000)
+ * @param expected  - Optional payment details to validate against on-chain operations
+ * @returns
+ *   true    — transaction exists, is successful, and (if expected given) details match
+ *   false   — transaction not found (404) or details mismatch
+ *   "error" — Horizon unreachable after all retries
+ */
+export async function verifyTransaction(
+  server: Horizon.Server,
+  txHash: string,
+  retries = 3,
+  backoffMs = 1000,
+  expected?: ExpectedTxDetails
+): Promise<boolean | "error"> {
+  const cacheKey = makeCacheKey(txHash, expected);
+  const cached = verificationCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < VERIFICATION_CACHE_TTL) {
+    return cached.result;
+  }
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const tx = await server.transactions().transaction(txHash).call();
+
+      if (!tx.successful) {
+        return false;
+      }
+
+      if (expected) {
+        const valid = await validatePaymentDetails(server, txHash, expected);
+        if (!valid) {
+          return false;
+        }
+      }
+
+      verificationCache.set(cacheKey, { result: true, timestamp: Date.now() });
+      return true;
+    } catch (e: unknown) {
+      if (isHorizon404(e)) {
+        return false;
+      }
+
+      if (attempt < retries) {
+        const delay = backoffMs * Math.pow(2, attempt - 1);
+        logger.warn({ txHash, attempt, delay }, "Horizon verification failed, retrying");
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      } else {
+        logger.error({ txHash, err: e }, "Horizon error verifying transaction after all retries");
+      }
+    }
+  }
+
+  return "error";
+}

--- a/backend/src/verify-transaction.test.ts
+++ b/backend/src/verify-transaction.test.ts
@@ -1,95 +1,557 @@
 import assert from "node:assert/strict";
 import { Horizon } from "@stellar/stellar-sdk";
+import {
+  verifyTransaction,
+  clearVerificationCache,
+  type ExpectedTxDetails,
+} from "./services/verify-transaction.js";
 
+// ── Live testnet server (used only where network access is acceptable) ────────
 const horizonUrl = "https://horizon-testnet.stellar.org";
-const server = new Horizon.Server(horizonUrl);
+const liveServer = new Horizon.Server(horizonUrl);
 
-async function verifyTransaction(
-  txHash: string,
-  retries = 3,
-  backoffMs = 1000
-): Promise<boolean | "error"> {
-  for (let attempt = 1; attempt <= retries; attempt++) {
-    try {
-      const tx = await server.transactions().transaction(txHash).call();
-      return tx.successful === true;
-    } catch (e: unknown) {
-      if (
-        e &&
-        typeof e === "object" &&
-        "response" in e &&
-        e.response &&
-        typeof e.response === "object" &&
-        "status" in e.response &&
-        e.response.status === 404
-      ) {
-        return false;
-      }
+// Known successful testnet transaction (hash stable on the ledger)
+const VALID_HASH = "687258079685320c270c5e933454378f8c6eb534e79ec3795c73c33324f9db21";
+const INVALID_HASH = "0000000000000000000000000000000000000000000000000000000000000000";
+const DUMMY_RECIPIENT = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGPCECWZLKOXUJEUKABC1";
 
-      if (attempt < retries) {
-        const delay = backoffMs * Math.pow(2, attempt - 1);
-        console.warn(`Attempt ${attempt} failed, retrying in ${delay}ms`);
-        await new Promise((resolve) => setTimeout(resolve, delay));
-      } else {
-        console.error("Horizon error after retries:", e);
-        return "error";
-      }
-    }
-  }
-  return "error";
+// ── Test infrastructure ───────────────────────────────────────────────────────
+
+interface MockOverrides {
+  txResult?: { successful: boolean; hash?: string; ledger?: number } | Error;
+  opsResult?: { records: unknown[] } | Error;
 }
+
+function makeMockServer(overrides: MockOverrides = {}): Horizon.Server {
+  return {
+    transactions: () => ({
+      transaction: () => ({
+        call: async () => {
+          if (overrides.txResult instanceof Error) throw overrides.txResult;
+          return overrides.txResult ?? { successful: true, hash: "mockhash", ledger: 1 };
+        },
+      }),
+    }),
+    operations: () => ({
+      forTransaction: () => ({
+        call: async () => {
+          if (overrides.opsResult instanceof Error) throw overrides.opsResult;
+          return overrides.opsResult ?? { records: [] };
+        },
+      }),
+    }),
+  } as unknown as Horizon.Server;
+}
+
+let passed = 0;
+let failed = 0;
+
+async function test(name: string, fn: () => Promise<void>) {
+  clearVerificationCache();
+  try {
+    await fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`  ❌ ${name}: ${msg}`);
+    failed++;
+  }
+}
+
+// ── Suites ────────────────────────────────────────────────────────────────────
+
+async function suiteBasicVerification() {
+  console.log("\n── Basic Verification ──────────────────────────────────────────\n");
+
+  await test("known valid transaction returns true (live testnet)", async () => {
+    const result = await verifyTransaction(liveServer, VALID_HASH);
+    assert.strictEqual(result, true);
+  });
+
+  await test("unknown hash (404) returns false (live testnet)", async () => {
+    const result = await verifyTransaction(liveServer, INVALID_HASH);
+    assert.strictEqual(result, false);
+  });
+
+  await test("unsuccessful transaction returns false", async () => {
+    const server = makeMockServer({ txResult: { successful: false } });
+    assert.strictEqual(await verifyTransaction(server, "hash1"), false);
+  });
+
+  await test("unreachable Horizon (non-404 error) returns 'error'", async () => {
+    const err = Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const server = makeMockServer({ txResult: err });
+    assert.strictEqual(await verifyTransaction(server, "hash2", 1, 10), "error");
+  });
+
+  await test("transaction exists and is successful returns true", async () => {
+    const server = makeMockServer({ txResult: { successful: true } });
+    assert.strictEqual(await verifyTransaction(server, "hash3"), true);
+  });
+}
+
+async function suiteDetailValidation() {
+  console.log("\n── Detail Validation ───────────────────────────────────────────\n");
+
+  const xlmPaymentOp = {
+    type: "payment",
+    to: DUMMY_RECIPIENT,
+    amount: "10.0000000",
+    asset_type: "native",
+  };
+
+  const successTx = { successful: true, hash: "abc", ledger: 1 };
+
+  await test("XLM payment with matching details returns true", async () => {
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [xlmPaymentOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "10",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), true);
+  });
+
+  await test("wrong amount returns false", async () => {
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [xlmPaymentOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "999",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), false);
+  });
+
+  await test("wrong recipient returns false", async () => {
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [xlmPaymentOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "10",
+      recipientAddress: "GDIFFERENTADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1",
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), false);
+  });
+
+  await test("wrong asset code returns false", async () => {
+    const usdcOp = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "10.0000000",
+      asset_type: "credit_alphanum4",
+      asset_code: "USDC",
+      asset_issuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    };
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [usdcOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "10",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM", // expects XLM but op is USDC
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), false);
+  });
+
+  await test("non-native asset with matching issuer returns true", async () => {
+    const issuer = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+    const usdcOp = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "50.0000000",
+      asset_type: "credit_alphanum4",
+      asset_code: "USDC",
+      asset_issuer: issuer,
+    };
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [usdcOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "50",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "USDC",
+      assetIssuer: issuer,
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), true);
+  });
+
+  await test("non-native asset with wrong issuer returns false", async () => {
+    const usdcOp = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "50.0000000",
+      asset_type: "credit_alphanum4",
+      asset_code: "USDC",
+      asset_issuer: "GABC",
+    };
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [usdcOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "50",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "USDC",
+      assetIssuer: "GXYZ",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), false);
+  });
+
+  await test("create_account operation validates as XLM payment", async () => {
+    const createOp = {
+      type: "create_account",
+      account: DUMMY_RECIPIENT,
+      starting_balance: "100.0000000",
+    };
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [createOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "100",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), true);
+  });
+
+  await test("create_account with wrong starting_balance returns false", async () => {
+    const createOp = {
+      type: "create_account",
+      account: DUMMY_RECIPIENT,
+      starting_balance: "100.0000000",
+    };
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [createOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "50", // mismatch
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), false);
+  });
+
+  await test("no matching operations in tx returns false", async () => {
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "10",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), false);
+  });
+
+  await test("first matching op among multiple wins", async () => {
+    const wrongOp = {
+      type: "payment",
+      to: "GWRONGRECIPIENTAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      amount: "10.0000000",
+      asset_type: "native",
+    };
+    const correctOp = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "10.0000000",
+      asset_type: "native",
+    };
+    const server = makeMockServer({
+      txResult: successTx,
+      opsResult: { records: [wrongOp, correctOp] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "10",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "abc", 3, 10, expected), true);
+  });
+}
+
+async function suiteCaching() {
+  console.log("\n── Caching ─────────────────────────────────────────────────────\n");
+
+  await test("second call with same hash hits cache (no repeat network call)", async () => {
+    let callCount = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => { callCount++; return { successful: true }; },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    await verifyTransaction(server, "cache-hash");
+    await verifyTransaction(server, "cache-hash");
+    assert.strictEqual(callCount, 1, "Horizon should be called exactly once");
+  });
+
+  await test("different hash bypasses cache", async () => {
+    let callCount = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => { callCount++; return { successful: true }; },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    await verifyTransaction(server, "hash-a");
+    await verifyTransaction(server, "hash-b");
+    assert.strictEqual(callCount, 2);
+  });
+
+  await test("same hash with different expected details creates separate cache entries", async () => {
+    let callCount = 0;
+    const op = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "10.0000000",
+      asset_type: "native",
+    };
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => { callCount++; return { successful: true }; },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [op] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    const base: ExpectedTxDetails = { amount: "10", recipientAddress: DUMMY_RECIPIENT, assetCode: "XLM" };
+    const different: ExpectedTxDetails = { amount: "20", recipientAddress: DUMMY_RECIPIENT, assetCode: "XLM" };
+
+    await verifyTransaction(server, "multi-key", 3, 10, base);
+    await verifyTransaction(server, "multi-key", 3, 10, different);
+    assert.strictEqual(callCount, 2, "Different expected details = different cache keys");
+  });
+
+  await test("failed (false) result is NOT cached", async () => {
+    let callCount = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => { callCount++; return { successful: false }; },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    await verifyTransaction(server, "false-hash");
+    await verifyTransaction(server, "false-hash");
+    assert.strictEqual(callCount, 2, "Non-successful txs should not be cached");
+  });
+}
+
+async function suiteExponentialBackoff() {
+  console.log("\n── Exponential Backoff ─────────────────────────────────────────\n");
+
+  await test("succeeds immediately without retrying (fast path)", async () => {
+    const startTime = Date.now();
+    const result = await verifyTransaction(liveServer, VALID_HASH, 2, 500);
+    const elapsed = Date.now() - startTime;
+    assert.strictEqual(result, true);
+    assert.ok(elapsed < 1000, `No retry expected on first-attempt success (elapsed: ${elapsed}ms)`);
+  });
+
+  await test("retries on transient error and succeeds on third attempt", async () => {
+    let attempt = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => {
+            attempt++;
+            if (attempt < 3) {
+              throw Object.assign(new Error("network error"), { code: "ECONNRESET" });
+            }
+            return { successful: true };
+          },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    const result = await verifyTransaction(server, "retry-hash", 3, 10);
+    assert.strictEqual(result, true);
+    assert.strictEqual(attempt, 3, "Should retry twice before succeeding");
+  });
+
+  await test("returns 'error' after exhausting all retries", async () => {
+    let attempt = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => {
+            attempt++;
+            throw Object.assign(new Error("persistent network error"), { code: "ECONNRESET" });
+          },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    const result = await verifyTransaction(server, "exhaust-hash", 3, 10);
+    assert.strictEqual(result, "error");
+    assert.strictEqual(attempt, 3, "Should attempt exactly 3 times");
+  });
+
+  await test("404 on retry attempt does not retry further", async () => {
+    let attempt = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => {
+            attempt++;
+            throw { response: { status: 404 }, message: "Not Found" };
+          },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    const result = await verifyTransaction(server, "404-hash", 3, 10);
+    assert.strictEqual(result, false);
+    assert.strictEqual(attempt, 1, "404 should short-circuit without retrying");
+  });
+
+  await test("backoff delay increases exponentially", async () => {
+    const delays: number[] = [];
+    let attempt = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => {
+            if (attempt > 0) delays.push(Date.now());
+            attempt++;
+            if (attempt <= 2) throw new Error("transient");
+            return { successful: true };
+          },
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({ call: async () => ({ records: [] }) }),
+      }),
+    } as unknown as Horizon.Server;
+
+    await verifyTransaction(server, "backoff-hash", 3, 50);
+
+    // First retry delay ~50ms, second ~100ms — second should always be longer
+    assert.ok(delays.length >= 1, "Should have retried at least once");
+  });
+}
+
+async function suiteEdgeCases() {
+  console.log("\n── Edge Cases ──────────────────────────────────────────────────\n");
+
+  await test("decimal amounts with trailing zeros match (10.0000000 === 10)", async () => {
+    const op = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "10.0000000",
+      asset_type: "native",
+    };
+    const server = makeMockServer({
+      txResult: { successful: true },
+      opsResult: { records: [op] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "10",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+    };
+    assert.strictEqual(await verifyTransaction(server, "decimal-hash", 3, 10, expected), true);
+  });
+
+  await test("null assetIssuer is treated as undefined (native asset)", async () => {
+    const op = {
+      type: "payment",
+      to: DUMMY_RECIPIENT,
+      amount: "5.0000000",
+      asset_type: "native",
+    };
+    const server = makeMockServer({
+      txResult: { successful: true },
+      opsResult: { records: [op] },
+    });
+    const expected: ExpectedTxDetails = {
+      amount: "5",
+      recipientAddress: DUMMY_RECIPIENT,
+      assetCode: "XLM",
+      assetIssuer: null,
+    };
+    assert.strictEqual(await verifyTransaction(server, "null-issuer-hash", 3, 10, expected), true);
+  });
+
+  await test("no expected details skips operation validation", async () => {
+    // Only checks tx.successful; does not call operations endpoint
+    let opCallCount = 0;
+    const server = {
+      transactions: () => ({
+        transaction: () => ({
+          call: async () => ({ successful: true }),
+        }),
+      }),
+      operations: () => ({
+        forTransaction: () => ({
+          call: async () => { opCallCount++; return { records: [] }; },
+        }),
+      }),
+    } as unknown as Horizon.Server;
+
+    await verifyTransaction(server, "no-expected");
+    assert.strictEqual(opCallCount, 0, "Operations endpoint should not be called without expected details");
+  });
+}
+
+// ── Run all suites ────────────────────────────────────────────────────────────
 
 async function runTests() {
-  console.log("Running Transaction Verification tests...\n");
+  console.log("Running Transaction Verification tests...");
 
-  const validHash = "687258079685320c270c5e933454378f8c6eb534e79ec3795c73c33324f9db21";
-  console.log("Test 1: Valid transaction verification");
-  try {
-    const result = await verifyTransaction(validHash);
-    assert.strictEqual(result, true, "Known valid transaction should return true");
-    console.log("✅ Valid transaction check passed\n");
-  } catch (e: unknown) {
-    const err = e as { message?: string };
-    console.error("❌ Valid transaction check failed:", err.message, "\n");
-  }
+  await suiteBasicVerification();
+  await suiteDetailValidation();
+  await suiteCaching();
+  await suiteExponentialBackoff();
+  await suiteEdgeCases();
 
-  const invalidHash = "0000000000000000000000000000000000000000000000000000000000000000";
-  console.log("Test 2: Invalid transaction hash");
-  try {
-    const result = await verifyTransaction(invalidHash);
-    assert.strictEqual(result, false, "Invalid hash should return false");
-    console.log("✅ Invalid transaction check passed (404)\n");
-  } catch (e: unknown) {
-    const err = e as { message?: string };
-    console.error("❌ Invalid transaction check failed:", err.message, "\n");
-  }
+  console.log("\n────────────────────────────────────────────────────────────────");
+  console.log(`Results: ${passed} passed, ${failed} failed`);
 
-  console.log("Test 3: Verify transaction details");
-  try {
-    const tx = await server.transactions().transaction(validHash).call();
-    assert.strictEqual(tx.successful, true, "Transaction should be successful");
-    assert.ok(tx.hash, "Transaction should have a hash");
-    assert.ok(tx.ledger, "Transaction should have a ledger");
-    console.log("✅ Transaction details verification passed\n");
-  } catch (e: unknown) {
-    const err = e as { message?: string };
-    console.error("❌ Transaction details check failed:", err.message, "\n");
-  }
-
-  console.log("Test 4: Exponential backoff on network errors");
-  const startTime = Date.now();
-  try {
-    const result = await verifyTransaction(validHash, 2, 100);
-    const elapsed = Date.now() - startTime;
-    assert.strictEqual(result, true, "Should succeed on first attempt");
-    assert.ok(elapsed < 500, "Should not retry on success");
-    console.log("✅ Backoff test passed (no retry needed)\n");
-  } catch (e: unknown) {
-    const err = e as { message?: string };
-    console.error("❌ Backoff test failed:", err.message, "\n");
-  }
-
-  console.log("All tests completed!");
+  if (failed > 0) process.exit(1);
 }
 
-runTests().catch(console.error);
+runTests().catch((e) => {
+  console.error("Unexpected test runner error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Extracted `verifyTransaction` logic into `backend/src/services/verify-transaction.ts` for testability and reuse
- **Validates payment details** (amount, recipient address, asset code/issuer) by fetching transaction operations from Horizon — not just `tx.successful`
- Supports both `payment` and `create_account` (XLM) operation types
- In-memory cache with 1-hour TTL, keyed on hash + expected details to avoid repeated Horizon calls
- Exponential backoff with configurable retries and base delay
- `app.ts` now passes `expectedDetails` from the submitted payload into the verifier, so fake/mismatched transactions are rejected at the API boundary
- Removed the skip-verification footgun: every `POST /support-transactions` call is fully verified
- Comprehensive test suite: basic verification, detail validation, caching, backoff behaviour, and edge cases

## Test plan

- [ ] Run `tsx src/verify-transaction.test.ts` in `backend/` — all suites should pass
- [ ] POST a valid testnet transaction with correct amount/recipient/asset → `201`
- [ ] POST a valid hash but wrong amount → `422` with detail-mismatch message
- [ ] POST a valid hash but wrong recipient → `422`
- [ ] POST an unknown hash → `422`
- [ ] Kill Horizon (or use invalid `HORIZON_URL`) → `503` after circuit-breaker trips

Closes #413
Closes #414
Closes #409