### PR TITLE
[Backend] ViewCount owner skip, text search on transactions, weekly digest cron, auto-award badges

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -39,6 +39,22 @@ async function main() {
     }
   });
 
+  // Seed badge definitions for auto-award system (#545)
+  const badgeDefinitions = [
+    { name: "First Supporter", description: "Received your very first support transaction", icon: "🎉", criteria: "first_support" },
+    { name: "10 Supporters", description: "10 unique supporters have contributed to your profile", icon: "🌟", criteria: "ten_supporters" },
+    { name: "100 XLM Club", description: "Received 100+ XLM in total support", icon: "💎", criteria: "total_100_xlm" },
+    { name: "Milestone Maker", description: "Reached at least one milestone", icon: "🏆", criteria: "milestone_reached" },
+  ];
+
+  for (const badge of badgeDefinitions) {
+    await prisma.badge.upsert({
+      where: { name: badge.name },
+      update: {},
+      create: badge,
+    });
+  }
+
   await prisma.supportTransaction.upsert({
     where: { txHash: "demo-tx-hash-stellar-testnet" },
     update: {},

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -44,6 +44,7 @@ import {
   verifyTransaction as verifyTransactionService,
   type ExpectedTxDetails,
 } from "./services/verify-transaction.js";
+import { checkAndAwardBadges } from "./services/badge-awarder.js";
 
 // Extend Express Request to include auth context
 declare global {
@@ -1196,12 +1197,16 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
       // Attempt to increment view count; viewCountLimiter will skip duplicate
       // IPs within the same hour window (applied as middleware below).
-      void prisma.profile.update({
-        where: { id: profile.id },
-        data: { viewCount: { increment: 1 } },
-      }).catch(() => {
-        // Non-fatal — do not block the response
-      });
+      // Skip increment if the viewer is the profile owner (#542).
+      const isOwner = req.auth?.userId && profile.ownerId === req.auth.userId;
+      if (!isOwner) {
+        void prisma.profile.update({
+          where: { id: profile.id },
+          data: { viewCount: { increment: 1 } },
+        }).catch(() => {
+          // Non-fatal — do not block the response
+        });
+      }
 
       const responseBody: Record<string, unknown> = { ...profile };
       if (req.auth) {
@@ -2221,6 +2226,11 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *           enum: [date, amount]
    *           default: date
    *         description: Sort transactions by date (newest first) or amount (highest first)
+   *       - in: query
+   *         name: q
+   *         schema:
+   *           type: string
+   *         description: Text search filter — returns only transactions whose message contains this string (case-insensitive, max 100 chars)
    *     responses:
    *       200:
    *         description: Paginated list of transactions
@@ -2307,6 +2317,8 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     const network = req.query.network as string | undefined;
     const status = req.query.status as string | undefined;
     const assetCode = req.query.assetCode as string | undefined;
+    const rawQ = req.query.q as string | undefined;
+    const q = rawQ?.trim().slice(0, 100) || undefined;
 
     // Validate sortBy — only "date" and "amount" are accepted
     const rawSortBy = req.query.sortBy as string | undefined;
@@ -2328,6 +2340,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       ...(network ? { stellarNetwork: network } : {}),
       ...(status ? { status } : {}),
       ...(assetCode ? { assetCode } : {}),
+      ...(q ? { message: { contains: q, mode: "insensitive" as const } } : {}),
     };
 
     // Sort by date (newest first) or amount (highest first)
@@ -2346,7 +2359,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       prisma.supportTransaction.count({ where }),
     ]);
 
-    res.json({ transactions, total, limit, offset, sortBy });
+    res.json({ transactions, total, limit, offset, sortBy, ...(q ? { q } : {}) });
   });
 
   // ── Export transactions for tax reporting ──────────────────────────────
@@ -3003,6 +3016,14 @@ All errors return JSON with an \`error\` field and optional \`code\`:
           );
         }
       })();
+
+      // Auto-award badges (fire-and-forget, never blocks the response) (#545)
+      checkAndAwardBadges(supportRecord.profileId).catch((err) => {
+        logger.error(
+          { err, txHash: supportRecord.txHash },
+          "Error in checkAndAwardBadges",
+        );
+      });
 
       req.log.info(
         { txHash: supportRecord.txHash },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -96,6 +96,7 @@ import { startDripScheduler } from "./services/drip-scheduler.js";
 import { startWebhookProcessor } from "./services/webhook-processor.js";
 import { EventIndexer } from "./services/event-indexer.js";
 import { createSorobanRpcClient } from "./services/soroban-rpc-client.js";
+import { startWeeklyDigestScheduler } from "./services/weekly-digest.js";
 import { prisma } from "./db.js";
 
 const port = Number(process.env.PORT ?? 4000);
@@ -131,6 +132,9 @@ app.listen(port, () => {
 
   // Start the recurring drip scheduler if enabled
   startDripScheduler();
+
+  // Start the weekly digest email scheduler
+  startWeeklyDigestScheduler();
 
   // Start the webhook delivery processor
   startWebhookProcessor();

--- a/backend/src/services/badge-awarder.ts
+++ b/backend/src/services/badge-awarder.ts
@@ -1,0 +1,84 @@
+import { prisma } from "../db.js";
+import { logger } from "../logger.js";
+
+function getBadgeNameByCriterion(criterion: string): string {
+  const map: Record<string, string> = {
+    first_support: "First Supporter",
+    ten_supporters: "10 Supporters",
+    total_100_xlm: "100 XLM Club",
+    milestone_reached: "Milestone Maker",
+  };
+  return map[criterion] ?? "";
+}
+
+export async function checkAndAwardBadges(profileId: string): Promise<void> {
+  try {
+    const badges = await prisma.badge.findMany();
+    if (badges.length === 0) return;
+
+    const existingAwards = await prisma.profileBadge.findMany({
+      where: { profileId },
+      select: { badgeId: true },
+    });
+    const awardedBadgeIds = new Set(existingAwards.map((a) => a.badgeId));
+
+    const [txCount, uniqueSupporters, totalsByAsset, milestonesReached] = await Promise.all([
+      prisma.supportTransaction.count({
+        where: { profileId, status: { not: "failed" } },
+      }),
+      prisma.supportTransaction.findMany({
+        where: { profileId, supporterAddress: { not: null }, status: { not: "failed" } },
+        distinct: ["supporterAddress"],
+        select: { supporterAddress: true },
+      }),
+      prisma.supportTransaction.groupBy({
+        by: ["assetCode"],
+        where: { profileId, status: { not: "failed" } },
+        _sum: { amount: true },
+      }),
+      prisma.milestone.count({
+        where: { profileId, status: "reached" },
+      }),
+    ]);
+
+    const xlmTotal = totalsByAsset
+      .filter((g) => g.assetCode === "XLM")
+      .reduce((sum, g) => sum + Number(g._sum.amount ?? 0), 0);
+
+    for (const badge of badges) {
+      if (awardedBadgeIds.has(badge.id)) continue;
+
+      let shouldAward = false;
+
+      switch (badge.criteria) {
+        case "first_support":
+          shouldAward = txCount >= 1;
+          break;
+        case "ten_supporters":
+          shouldAward = uniqueSupporters.length >= 10;
+          break;
+        case "total_100_xlm":
+          shouldAward = xlmTotal >= 100;
+          break;
+        case "milestone_reached":
+          shouldAward = milestonesReached >= 1;
+          break;
+      }
+
+      if (shouldAward) {
+        await prisma.profileBadge.create({
+          data: { profileId, badgeId: badge.id },
+        });
+        logger.info(
+          { profileId, badgeName: badge.name },
+          "Badge auto-awarded",
+        );
+      }
+    }
+  } catch (err) {
+    logger.error(
+      { err, profileId },
+      "Error in checkAndAwardBadges",
+    );
+  }
+}

--- a/backend/src/services/weekly-digest.ts
+++ b/backend/src/services/weekly-digest.ts
@@ -1,0 +1,146 @@
+import { prisma } from "../db.js";
+import { sendEmail } from "../mailer.js";
+import { logger } from "../logger.js";
+
+export async function sendWeeklyDigests() {
+  const profiles = await prisma.profile.findMany({
+    where: {
+      email: { not: null },
+      emailVerified: true,
+      notificationPreferences: { weeklyDigest: true },
+    },
+    include: {
+      notificationPreferences: true,
+    },
+  });
+
+  logger.info({ profilesToProcess: profiles.length }, "Weekly digest run started");
+
+  let profilesEmailed = 0;
+  let errors = 0;
+
+  for (const profile of profiles) {
+    try {
+      const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+      const [transactions, uniqueSupporters, milestonesReached, assetGroups] = await Promise.all([
+        prisma.supportTransaction.findMany({
+          where: {
+            profileId: profile.id,
+            status: { not: "failed" },
+            createdAt: { gte: sevenDaysAgo },
+          },
+          orderBy: { createdAt: "desc" },
+        }),
+        prisma.supportTransaction.findMany({
+          where: {
+            profileId: profile.id,
+            supporterAddress: { not: null },
+            createdAt: { gte: sevenDaysAgo },
+          },
+          distinct: ["supporterAddress"],
+          select: { supporterAddress: true },
+        }),
+        prisma.milestone.findMany({
+          where: {
+            profileId: profile.id,
+            status: "reached",
+            updatedAt: { gte: sevenDaysAgo },
+          },
+        }),
+        prisma.supportTransaction.groupBy({
+          by: ["assetCode"],
+          where: {
+            profileId: profile.id,
+            status: { not: "failed" },
+            createdAt: { gte: sevenDaysAgo },
+          },
+          _sum: { amount: true },
+          _count: true,
+        }),
+      ]);
+
+      const totalReceived = transactions.reduce(
+        (sum, tx) => sum + Number(tx.amount),
+        0,
+      );
+      const txCount = transactions.length;
+      const supporterCount = uniqueSupporters.length;
+      const milestonesCount = milestonesReached.length;
+
+      if (txCount === 0) continue;
+
+      const assetBreakdown = assetGroups
+        .map((g) => `${g._sum.amount?.toFixed(7) ?? "0"} ${g.assetCode}`)
+        .join(", ");
+
+      const milestonesSection =
+        milestonesCount > 0
+          ? `<p><strong>Milestones reached:</strong> ${milestonesCount}</p>`
+          : "";
+
+      const html = `
+        <h2>Your Weekly NovaSupport Recap</h2>
+        <p>Here's what happened with your profile <strong>${profile.displayName}</strong> this week:</p>
+        <ul>
+          <li><strong>Total received:</strong> ${totalReceived.toFixed(7)} (${assetBreakdown})</li>
+          <li><strong>Transactions:</strong> ${txCount}</li>
+          <li><strong>New supporters:</strong> ${supporterCount}</li>
+        </ul>
+        ${milestonesSection}
+        <br/>
+        <p><a href="https://novasupport.xyz/${profile.username}">View your profile</a></p>
+        <br/>
+        <p>Thanks,<br/>The NovaSupport Team</p>
+      `;
+
+      await sendEmail({
+        to: profile.email!,
+        subject: "Your NovaSupport weekly recap",
+        html,
+      });
+
+      profilesEmailed++;
+    } catch (err) {
+      logger.error(
+        { err, profileId: profile.id },
+        "Failed to send weekly digest for profile",
+      );
+      errors++;
+    }
+  }
+
+  logger.info(
+    { profilesEmailed, errors },
+    "Weekly digest run completed",
+  );
+}
+
+let digestInterval: ReturnType<typeof setInterval> | null = null;
+
+export function startWeeklyDigestScheduler() {
+  if (process.env.WEEKLY_DIGEST_ENABLED === "true") {
+    logger.info("Weekly digest scheduler enabled. Starting...");
+
+    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+    sendWeeklyDigests().catch((err) => {
+      logger.error({ err }, "Error in initial sendWeeklyDigests run");
+    });
+
+    digestInterval = setInterval(() => {
+      sendWeeklyDigests().catch((err) => {
+        logger.error({ err }, "Error in sendWeeklyDigests interval");
+      });
+    }, SEVEN_DAYS_MS);
+  } else {
+    logger.info("Weekly digest scheduler disabled. Set WEEKLY_DIGEST_ENABLED=true to enable.");
+  }
+}
+
+export function stopWeeklyDigestScheduler() {
+  if (digestInterval) {
+    clearInterval(digestInterval);
+    digestInterval = null;
+  }
+}


### PR DESCRIPTION
## Description

Combined PR for four backend issues.

### #542 — Increment viewCount with owner JWT skip
The existing viewCount increment now checks `req.auth` — if the viewer is the profile owner, the count is NOT incremented (avoids inflating your own view count).

**Changes:**
- `backend/src/app.ts` — wrap increment in `!isOwner` guard

### #543 — Text search on transactions
Adds an optional `q` query parameter to `GET /profiles/:username/transactions` that filters by message text (case-insensitive `contains`). Combined with existing filters via AND logic. Max 100 chars. Included in the response. JSDoc updated.

**Changes:**
- `backend/src/app.ts` — `q` param parsing + Prisma `where` condition + response inclusion

### #544 — Weekly digest email cron job
Creates `backend/src/services/weekly-digest.ts` with `sendWeeklyDigests()` and `startWeeklyDigestScheduler()`. Queries opted-in profiles (weeklyDigest=true, email verified), aggregates 7-day stats (total by asset, tx count, new supporters, milestones), and sends a styled recap email. Gated behind `WEEKLY_DIGEST_ENABLED=true`. Wired into `backend/src/index.ts`.

**Changes:**
- `backend/src/services/weekly-digest.ts` — new service
- `backend/src/index.ts` — import + start scheduler

### #545 — Auto-award badges on transaction milestones
Creates `backend/src/services/badge-awarder.ts` with `checkAndAwardBadges()`. After each successful support transaction, checks badge criteria (first_support, ten_supporters, total_100_xlm, milestone_reached) and auto-awards any unmet badges. Fire-and-forget — never blocks the response. Also seeds the four badge definitions in `prisma/seed.ts`.

**Changes:**
- `backend/src/services/badge-awarder.ts` — new service
- `backend/src/app.ts` — import + fire-and-forget call in POST handler
- `backend/prisma/seed.ts` — badge seed definitions

Closes #542, closes #543, closes #544, closes #545