### PR TITLE
novasupport implementations

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -3,13 +3,10 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { AppShell } from "@/components/app-shell";
+import { Toast } from "@/components/toast";
 import { 
   TrendingUp, Users, Wallet, Activity, 
-  ArrowUpRight, ArrowDownRight, Plus, Edit2, Trash2, X, Link2, Eye, EyeOff, Copy, Check, ChevronDown, ChevronRight
-import { NotificationPreferences } from "@/components/notification-preferences";
-import {
-  TrendingUp, Users, Wallet, Activity,
-  ArrowUpRight, ArrowDownRight, Plus, Edit2, Trash2, X
+  ArrowUpRight, ArrowDownRight, Plus, Edit2, Trash2, X, Link2, Eye, EyeOff, Copy, Check, ChevronDown, ChevronRight, Download
 } from "lucide-react";
 import { motion } from "framer-motion";
 import { formatRateLimitedMessage, parseRateLimitInfo } from "@/lib/rate-limit";
@@ -85,6 +82,8 @@ export default function DashboardPage() {
   const [expandedDeliveries, setExpandedDeliveries] = useState<string | null>(null);
   const [deliveries, setDeliveries] = useState<Record<string, WebhookDelivery[]>>({});
   const [deliveriesLoading, setDeliveriesLoading] = useState<string | null>(null);
+  const [csvLoading, setCsvLoading] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
   useEffect(() => {
     async function loadDashboard() {
@@ -301,6 +300,35 @@ export default function DashboardPage() {
       document.body.removeChild(textarea);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleDownloadCsv = async () => {
+    if (!username) return;
+    setCsvLoading(true);
+    try {
+      const token = localStorage.getItem("authToken");
+      const res = await fetch(`${API_BASE_URL}/profiles/${username}/transactions/export`, {
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to download CSV");
+      }
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `novasupport-transactions-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      setToast({ message: err.message || "Failed to download CSV", type: "error" });
+    } finally {
+      setCsvLoading(false);
     }
   };
 
@@ -774,7 +802,47 @@ export default function DashboardPage() {
             </div>
           )}
         </section>
+
+        {/* Transactions Section */}
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-steel">
+              Transactions
+            </h2>
+            <button
+              onClick={handleDownloadCsv}
+              disabled={csvLoading}
+              className="flex items-center gap-2 rounded-lg bg-mint/10 px-4 py-2 text-xs font-semibold text-mint hover:bg-mint/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {csvLoading ? (
+                <>
+                  <div className="h-3 w-3 animate-spin rounded-full border border-mint border-t-transparent" />
+                  Downloading...
+                </>
+              ) : (
+                <>
+                  <Download size={14} />
+                  Download CSV
+                </>
+              )}
+            </button>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+            <p className="text-sm text-steel">
+              Download all your transactions as a CSV file for accounting and analysis purposes.
+            </p>
+          </div>
+        </section>
       </div>
+
+      {toast && (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          onDismiss={() => setToast(null)}
+        />
+      )}
     </AppShell>
   );
 }

--- a/frontend/src/components/profile-tabs.tsx
+++ b/frontend/src/components/profile-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import {
   History, Award, LayoutDashboard,
   ExternalLink, Search, Calendar, X
@@ -8,6 +8,7 @@ import {
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
 import { EmptyState } from "./empty-state";
+import { useRouter } from "next/navigation";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
 
@@ -68,11 +69,43 @@ function Highlight({ text, query }: { text: string; query: string }) {
 }
 
 export function ProfileTabs({ username }: { username: string }) {
+  const router = useRouter();
   const [activeTab, setActiveTab] = useState<"history" | "badges">("history");
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [badges, setBadges] = useState<Badge[]>([]);
   const [loading, setLoading] = useState(false);
   const [badgesLoading, setBadgesLoading] = useState(false);
+
+  // ── URL hash sync ───────────────────────────────────────────────────────
+  useEffect(() => {
+    // Read hash on mount
+    const hash = window.location.hash.slice(1); // Remove the #
+    if (hash === "badges") {
+      setActiveTab("badges");
+    } else {
+      setActiveTab("history"); // Default to history
+    }
+
+    // Listen for hash changes (back/forward navigation)
+    const handleHashChange = () => {
+      const newHash = window.location.hash.slice(1);
+      if (newHash === "badges") {
+        setActiveTab("badges");
+      } else {
+        setActiveTab("history");
+      }
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
+  // Update URL hash when tab changes
+  const handleTabChange = useCallback((tab: "history" | "badges") => {
+    setActiveTab(tab);
+    const newHash = tab === "badges" ? "#badges" : "#history";
+    window.history.replaceState(null, "", newHash);
+  }, []);
 
   // ── Search state (#472) ────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
@@ -155,13 +188,13 @@ export function ProfileTabs({ username }: { username: string }) {
         <div className="flex gap-8">
           <TabButton
             active={activeTab === "history"}
-            onClick={() => setActiveTab("history")}
+            onClick={() => handleTabChange("history")}
             icon={<History size={16} />}
             label="Support History"
           />
           <TabButton
             active={activeTab === "badges"}
-            onClick={() => setActiveTab("badges")}
+            onClick={() => handleTabChange("badges")}
             icon={<Award size={16} />}
             label="Badges"
           />


### PR DESCRIPTION
## What does this PR do?

This PR adds two new features to improve user experience and data accessibility:

1. **URL hash-based tab navigation** for profile pages - users can now deep-link to specific tabs (e.g., `/profile/username#badges`) and the URL updates when switching tabs without page reload
2. **Download CSV button** in the dashboard transactions section - creators can now export all their transactions as a CSV file with a single click, using the `/v1/profiles/:username/transactions/export` endpoint

## Related issue

Closes #
Closes #546 
Closes #549 
Closes #550 
Closes #553

## Type of change

- [x] New feature

## How to test

1. **Test URL hash navigation on profile page:**
   - Navigate to a profile page (e.g., `/profile/stellar-dev`)
   - Click on different tabs (Support History, Badges)
   - Verify the URL hash updates to `#history` or `#badges`
   - Refresh the page with a hash - verify the correct tab is selected
   - Test browser back/forward navigation between tabs

2. **Test CSV download in dashboard:**
   - Navigate to the creator dashboard
   - Scroll to the Transactions section
   - Click the "Download CSV" button
   - Verify a loading spinner appears during the fetch
   - Verify the CSV file downloads with filename format `novasupport-transactions-{date}.csv`
   - Test error handling by attempting to download without auth (should show error toast)

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [ ] My branch is up to date with main
- [ ] Linter passes (`npm run lint`)
- [ ] Tests pass (`npm test`) if applicable
- [ ] I have not committed `.env` files or secrets