### PR TITLE
feat: add RSS feed button, per-toggle notification saves, debounced search, activity feed

### DIFF
--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -5,6 +5,7 @@ import { ProfileCard } from "@/components/profile-card";
 import { SupportPanel } from "@/components/support-panel";
 import { ProfileTabs } from "@/components/profile-tabs";
 import { QRCodeButton } from "@/components/qr-code-button";
+import { RSSFeedButton } from "@/components/rss-feed-button";
 import { EmptyState } from "@/components/empty-state";
 import { EmbedCodeGenerator } from "@/components/embed-widget";
 import { MilestoneCard } from "@/components/milestone-card";
@@ -241,8 +242,9 @@ export default async function ProfilePage({ params }: PageProps) {
               isVerified={profile.emailVerified}
               stats={stats || undefined}
             />
-            <div className="px-2">
+            <div className="px-2 flex gap-2">
               <QRCodeButton username={profile.username} />
+              <RSSFeedButton username={profile.username} />
             </div>
           </div>
 

--- a/frontend/src/components/notification-preferences.tsx
+++ b/frontend/src/components/notification-preferences.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
+import { Check } from "lucide-react";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
 
@@ -21,9 +22,10 @@ export function NotificationPreferences({ username }: Props) {
     weeklyDigest: false,
   });
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [saved, setSaved] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
+  const [emailVerified, setEmailVerified] = useState<boolean | null>(null);
 
   useEffect(() => {
     const token = localStorage.getItem("authToken");
@@ -32,51 +34,68 @@ export function NotificationPreferences({ username }: Props) {
       return;
     }
 
-    fetch(`${API_BASE_URL}/profiles/${username}/notification-preferences`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) setPrefs(data);
+    Promise.all([
+      fetch(`${API_BASE_URL}/profiles/${username}/notification-preferences`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      fetch(`${API_BASE_URL}/profiles/${username}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    ])
+      .then(([prefsRes, profileRes]) =>
+        Promise.all([
+          prefsRes.ok ? prefsRes.json() : null,
+          profileRes.ok ? profileRes.json() : null,
+        ]),
+      )
+      .then(([prefsData, profileData]) => {
+        if (prefsData) setPrefs(prefsData);
+        if (profileData) setEmailVerified(profileData.emailVerified ?? false);
       })
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [username]);
 
-  const handleToggle = (key: keyof Prefs) => {
-    setPrefs((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
+  const handleToggle = useCallback(
+    async (key: keyof Prefs) => {
+      const newValue = !prefs[key];
+      setPrefs((prev) => ({ ...prev, [key]: newValue }));
+      setSaving(key);
+      setError(null);
 
-  const handleSave = async () => {
-    setSaving(true);
-    setError(null);
-    try {
-      const token = localStorage.getItem("authToken");
-      const res = await fetch(
-        `${API_BASE_URL}/profiles/${username}/notification-preferences`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      try {
+        const token = localStorage.getItem("authToken");
+        const res = await fetch(
+          `${API_BASE_URL}/profiles/${username}/notification-preferences`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+              ...(token ? { Authorization: `Bearer ${token}` } : {}),
+            },
+            body: JSON.stringify({ [key]: newValue }),
           },
-          body: JSON.stringify(prefs),
-        },
-      );
+        );
 
-      if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.error ?? "Failed to save preferences");
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error ?? "Failed to save preference");
+        }
+
+        setSaved((prev) => ({ ...prev, [key]: true }));
+        setTimeout(
+          () => setSaved((prev) => ({ ...prev, [key]: false })),
+          2000,
+        );
+      } catch (err: unknown) {
+        setPrefs((prev) => ({ ...prev, [key]: !newValue }));
+        setError(err instanceof Error ? err.message : "Something went wrong");
+      } finally {
+        setSaving(null);
       }
-
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2500);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Something went wrong");
-    } finally {
-      setSaving(false);
-    }
-  };
+    },
+    [prefs, username],
+  );
 
   if (loading) return null;
 
@@ -101,37 +120,41 @@ export function NotificationPreferences({ username }: Props) {
           label="New support received"
           description="Get an email when someone sends you support."
           checked={prefs.notifyOnSupport}
+          saving={saving === "notifyOnSupport"}
+          saved={!!saved.notifyOnSupport}
           onToggle={() => handleToggle("notifyOnSupport")}
           toggleClass={toggleClass}
           knobClass={knobClass}
         />
         <PreferenceRow
           label="Milestone reached"
-          description="Get an email when a funding goal is completed."
+          description="Notify me when one of my funding goals is reached."
           checked={prefs.notifyOnMilestone}
+          saving={saving === "notifyOnMilestone"}
+          saved={!!saved.notifyOnMilestone}
           onToggle={() => handleToggle("notifyOnMilestone")}
           toggleClass={toggleClass}
           knobClass={knobClass}
         />
         <PreferenceRow
           label="Weekly digest"
-          description="Receive a weekly summary of your support activity."
+          description="Send me a weekly summary of my support activity."
           checked={prefs.weeklyDigest}
+          saving={saving === "weeklyDigest"}
+          saved={!!saved.weeklyDigest}
           onToggle={() => handleToggle("weeklyDigest")}
           toggleClass={toggleClass}
           knobClass={knobClass}
         />
       </div>
 
-      {error && <p className="text-xs text-red-400">{error}</p>}
+      {emailVerified === false && (
+        <p className="text-xs text-amber-400">
+          Verify your email to receive notifications
+        </p>
+      )}
 
-      <button
-        onClick={handleSave}
-        disabled={saving}
-        className="min-h-[44px] w-full rounded-xl bg-[#00e5b0] px-4 py-2 text-sm font-semibold text-black hover:bg-[#00c99a] transition-colors disabled:opacity-50"
-      >
-        {saving ? "Saving…" : saved ? "Saved!" : "Save preferences"}
-      </button>
+      {error && <p className="text-xs text-red-400">{error}</p>}
     </section>
   );
 }
@@ -140,6 +163,8 @@ function PreferenceRow({
   label,
   description,
   checked,
+  saving,
+  saved,
   onToggle,
   toggleClass,
   knobClass,
@@ -147,6 +172,8 @@ function PreferenceRow({
   label: string;
   description: string;
   checked: boolean;
+  saving: boolean;
+  saved: boolean;
   onToggle: () => void;
   toggleClass: (on: boolean) => string;
   knobClass: (on: boolean) => string;
@@ -157,14 +184,23 @@ function PreferenceRow({
         <p className="text-sm font-medium text-white">{label}</p>
         <p className="text-xs text-white/40 mt-0.5">{description}</p>
       </div>
-      <button
-        role="switch"
-        aria-checked={checked}
-        onClick={onToggle}
-        className={toggleClass(checked)}
-      >
-        <span className={knobClass(checked)} />
-      </button>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {saved && (
+          <span className="flex items-center gap-0.5 text-[10px] text-mint">
+            <Check size={10} />
+            Saved
+          </span>
+        )}
+        <button
+          role="switch"
+          aria-checked={checked}
+          onClick={onToggle}
+          disabled={saving}
+          className={toggleClass(checked)}
+        >
+          <span className={knobClass(checked)} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/profile-tabs.tsx
+++ b/frontend/src/components/profile-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import {
   History, Award, LayoutDashboard,
   ExternalLink, Search, Calendar, X
@@ -21,7 +21,6 @@ type Transaction = {
   supporterAddress?: string;
   createdAt: string;
   status: string;
-//   message?: string;
   memo?: string | null;
 };
 
@@ -107,8 +106,10 @@ export function ProfileTabs({ username }: { username: string }) {
     window.history.replaceState(null, "", newHash);
   }, []);
 
-  // ── Search state (#472) ────────────────────────────────────────────────────
+  // ── Search state (#554) ────────────────────────────────────────────────────
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Date filter state (#461) ───────────────────────────────────────────────
   const [preset, setPreset] = useState<DatePreset>("all");
@@ -121,10 +122,29 @@ export function ProfileTabs({ username }: { username: string }) {
     FAILED:  "bg-red-100 text-red-800",
   };
 
+  // Debounce search term 300ms then update debouncedSearch
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(value);
+    }, 300);
+  }, []);
+
+  // Cleanup debounce on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   useEffect(() => {
     if (activeTab === "history") {
       setLoading(true);
-      fetch(`${API_BASE_URL}/profiles/${username}/transactions`)
+      const params = new URLSearchParams();
+      if (debouncedSearch.trim()) params.set("q", debouncedSearch.trim());
+      const url = `${API_BASE_URL}/profiles/${username}/transactions${params.toString() ? "?" + params.toString() : ""}`;
+      fetch(url)
         .then(res => res.json())
         .then(data => {
           setTransactions(data.transactions || []);
@@ -140,13 +160,12 @@ export function ProfileTabs({ username }: { username: string }) {
         .catch(err => console.error(err))
         .finally(() => setBadgesLoading(false));
     }
-  }, [username, activeTab]);
+  }, [username, activeTab, debouncedSearch]);
 
-  // ── Filtered transactions ──────────────────────────────────────────────────
+  // ── Filtered transactions (date only; search handled by API) ──────────────
   const filtered = useMemo(() => {
     let result = transactions;
 
-    // Date range filter
     const { from, to } = preset === "custom"
       ? {
           from: customFrom ? new Date(customFrom) : null,
@@ -157,23 +176,12 @@ export function ProfileTabs({ username }: { username: string }) {
     if (from) result = result.filter(tx => new Date(tx.createdAt) >= from);
     if (to)   result = result.filter(tx => new Date(tx.createdAt) <= to);
 
-    // Search filter (#472) — supporter address, message, amount
-    const q = search.trim().toLowerCase();
-    if (q) {
-      result = result.filter(tx => {
-        const addr    = (tx.supporterAddress ?? "").toLowerCase();
-        const msg     = (tx.message ?? "").toLowerCase();
-        const amount  = tx.amount.toLowerCase();
-        const asset   = tx.assetCode.toLowerCase();
-        return addr.includes(q) || msg.includes(q) || amount.includes(q) || asset.includes(q);
-      });
-    }
-
     return result;
-  }, [transactions, search, preset, customFrom, customTo]);
+  }, [transactions, preset, customFrom, customTo]);
 
   const clearFilters = () => {
     setSearch("");
+    setDebouncedSearch("");
     setPreset("all");
     setCustomFrom("");
     setCustomTo("");
@@ -220,16 +228,28 @@ export function ProfileTabs({ username }: { username: string }) {
           >
             {/* ── Search & filter toolbar ────────────────────────────────── */}
             <div className="flex flex-col sm:flex-row gap-3">
-              {/* Search input (#472) */}
+              {/* Search input (#554) */}
               <div className="relative flex-1">
                 <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-steel" />
                 <input
                   type="text"
                   value={search}
-                  onChange={e => setSearch(e.target.value)}
-                  placeholder="Search address, message, amount…"
-                  className="w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-4 py-2 text-sm text-white placeholder:text-steel focus:border-mint/40 focus:outline-none focus:ring-1 focus:ring-mint/30 transition"
+                  onChange={e => handleSearchChange(e.target.value)}
+                  placeholder="Search by message…"
+                  className="w-full rounded-xl border border-white/10 bg-white/5 pl-9 pr-9 py-2 text-sm text-white placeholder:text-steel focus:border-mint/40 focus:outline-none focus:ring-1 focus:ring-mint/30 transition"
                 />
+                {search && (
+                  <button
+                    onClick={() => {
+                      setSearch("");
+                      setDebouncedSearch("");
+                    }}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-steel hover:text-white transition"
+                    aria-label="Clear search"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
               </div>
 
               {/* Date range preset buttons (#461) */}
@@ -373,24 +393,33 @@ export function ProfileTabs({ username }: { username: string }) {
                 </table>
               </div>
             ) : (
-              <div className="flex flex-col items-center justify-center py-16 text-center">
-                {transactions.length > 0 ? (
-                  <>
-                    <p className="text-gray-500 font-medium">No matching transactions</p>
-                    <p className="text-sm text-gray-400 mt-1">Try adjusting your search or date filters.</p>
-                  </>
-                ) : (
-                  <>
-                    <p className="text-gray-500 font-medium">No support yet</p>
-                    <p className="text-sm text-gray-400 mt-1">Be the first to support {username}!</p>
-                  </>
-                )}
-              </div>
-              <EmptyState
-                variant="transactions"
-                title="No transactions yet"
-                description="Be the first to support this creator!"
-              />
+              <>
+                <div className="flex flex-col items-center justify-center py-16 text-center">
+                  {transactions.length > 0 ? (
+                    debouncedSearch ? (
+                      <>
+                        <p className="text-gray-500 font-medium">No transactions match your search</p>
+                        <p className="text-sm text-gray-400 mt-1">Try a different keyword.</p>
+                      </>
+                    ) : (
+                      <>
+                        <p className="text-gray-500 font-medium">No matching transactions</p>
+                        <p className="text-sm text-gray-400 mt-1">Try adjusting your search or date filters.</p>
+                      </>
+                    )
+                  ) : (
+                    <>
+                      <p className="text-gray-500 font-medium">No support yet</p>
+                      <p className="text-sm text-gray-400 mt-1">Be the first to support {username}!</p>
+                    </>
+                  )}
+                </div>
+                <EmptyState
+                  variant="no-transactions"
+                  title="No transactions yet"
+                  description="Be the first to support this creator!"
+                />
+              </>
             )}
           </motion.div>
         ) : (

--- a/frontend/src/components/rss-feed-button.tsx
+++ b/frontend/src/components/rss-feed-button.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Rss, Check } from "lucide-react";
+import { API_BASE_URL } from "@/lib/config";
+
+type RSSFeedButtonProps = {
+  username: string;
+};
+
+export function RSSFeedButton({ username }: RSSFeedButtonProps) {
+  const [showToast, setShowToast] = useState(false);
+
+  const feedUrl = `${API_BASE_URL}/v1/profiles/${username}/feed.xml`;
+
+  const handleClick = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(feedUrl);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = feedUrl;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 2000);
+  }, [feedUrl]);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label="Copy RSS feed URL"
+        className="inline-flex items-center gap-1.5 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-medium text-sky/80 transition hover:bg-white/10 hover:text-white"
+      >
+        <Rss size={14} />
+        RSS Feed
+      </button>
+
+      {showToast && (
+        <div className="absolute left-1/2 top-full z-50 mt-2 -translate-x-1/2 whitespace-nowrap rounded-lg border border-white/10 bg-[#0A0A0B] px-3 py-2 shadow-2xl sm:left-0 sm:translate-x-0">
+          <div className="flex items-center gap-1.5 text-xs text-mint">
+            <Check size={12} />
+            RSS feed URL copied
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the following issues:

### #547 - Add RSS feed link on public profile page
- Created `rss-feed-button.tsx` client component with RSS icon
- Click copies feed URL to clipboard and shows a confirmation toast
- Added button next to QR code button in profile header
- RSS alternates metadata already present in `generateMetadata`

### #551 - Add milestone-reached and weekly digest toggles to notification preferences
- All three toggles (`notifyOnSupport`, `notifyOnMilestone`, `weeklyDigest`) now save immediately on toggle (removed save button)
- Each toggle shows a subtle "Saved" confirmation after successful PATCH
- Added email verification warning when profile has no verified email
- Reverts toggle on API failure (optimistic UI with rollback)

### #554 - Add transaction text search input to profile transactions tab
- Search input now debounces 300ms before sending API request with `?q=` parameter
- Added clear button (×) inside the search input
- Shows "No transactions match your search" empty state when search is active with no results
- Preserves existing date range filters alongside search

### #555 - Wire activity-feed component into public profile page
- `ActivityFeed` already rendered on profile page with `username` and `limit` props
- Component handles empty state, loading, and error states
- No polling/intervals — no memory leak concerns

## Testing
- `npm run lint` — passes (only pre-existing warnings)
- `npm test` — no new failures introduced

Closes #547, Closes #551, Closes #554, Closes #555