### PR TITLE
feat: add Web Share API button to profile page and view profile link …

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { AppShell } from "@/components/app-shell";
 import { Toast } from "@/components/toast";
 import { 
@@ -381,9 +382,19 @@ export default function DashboardPage() {
           <h1 className="text-3xl font-bold tracking-tight text-white">
             Creator <span className="text-mint">Dashboard</span>
           </h1>
-          <p className="text-steel">
-            Manage your profile and funding goals
-          </p>
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-steel">
+              Manage your profile and funding goals
+            </p>
+            {username && (
+              <Link
+                href={`/profile/${username}`}
+                className="shrink-0 text-sm text-sky/60 hover:text-mint transition-colors"
+              >
+                View public profile →
+              </Link>
+            )}
+          </div>
         </header>
 
         {/* Summary Cards */}

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -6,6 +6,7 @@ import { SupportPanel } from "@/components/support-panel";
 import { ProfileTabs } from "@/components/profile-tabs";
 import { QRCodeButton } from "@/components/qr-code-button";
 import { RSSFeedButton } from "@/components/rss-feed-button";
+import { ShareButton } from "@/components/share-button";
 import { EmptyState } from "@/components/empty-state";
 import { EmbedCodeGenerator } from "@/components/embed-widget";
 import { MilestoneCard } from "@/components/milestone-card";
@@ -245,6 +246,7 @@ export default async function ProfilePage({ params }: PageProps) {
             <div className="px-2 flex gap-2">
               <QRCodeButton username={profile.username} />
               <RSSFeedButton username={profile.username} />
+              <ShareButton displayName={profile.displayName} username={profile.username} />
             </div>
           </div>
 

--- a/frontend/src/components/share-button.tsx
+++ b/frontend/src/components/share-button.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+
+type ShareButtonProps = {
+  displayName: string;
+  username: string;
+};
+
+export function ShareButton({ displayName, username }: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const profileUrl = `https://novasupport.xyz/profile/${username}`;
+
+  const handleShare = async () => {
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({
+          title: `${displayName} on NovaSupport`,
+          text: `Support ${displayName} on Stellar`,
+          url: profileUrl,
+        });
+      } catch (err) {
+        // User dismissed the share sheet — ignore AbortError silently
+        if (err instanceof Error && err.name !== "AbortError") {
+          // Non-abort error: fall back to clipboard
+          await copyToClipboard();
+        }
+      }
+    } else {
+      // Desktop fallback: copy to clipboard
+      await copyToClipboard();
+    }
+  };
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(profileUrl);
+    } catch {
+      // Legacy fallback
+      const textarea = document.createElement("textarea");
+      textarea.value = profileUrl;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className="inline-flex min-h-[36px] items-center gap-1.5 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-medium text-white hover:bg-white/10 transition-colors"
+    >
+      {copied ? (
+        <>
+          <span>✓</span>
+          <span>Link copied!</span>
+        </>
+      ) : (
+        <>
+          <span>↑</span>
+          <span>Share</span>
+        </>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
…to dashboard

- Add ShareButton client component that calls navigator.share() on mobile and falls back to clipboard copy with confirmation on desktop
- AbortError (user dismissed share sheet) is handled silently
- Place ShareButton next to QRCodeButton and RSSFeedButton on profile page
- Add 'View public profile →' link to Creator Dashboard header
- Link resolves to /profile/:username using username from localStorage
- Link is visible on both mobile and desktop, styled as a subtle secondary link

Closes #566
Closes #565

## What does this PR do?

<!-- A clear 1-3 sentence summary of the change -->

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test

<!-- Step-by-step instructions for a reviewer to verify this works -->

1.
2.
3.

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [ ] My branch is up to date with main
- [ ] Linter passes (`npm run lint`)
- [ ] Tests pass (`npm test`) if applicable
- [ ] I have not committed `.env` files or secrets
