### PR TITLE
fix: avatar guard, Send Support button, recurring validation, indexer memory

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -743,7 +743,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -765,7 +764,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -802,7 +800,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -1342,7 +1339,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -2008,7 +2004,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2325,7 +2320,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3243,7 +3237,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3473,7 +3466,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4235,7 +4227,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4872,7 +4863,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5069,7 +5059,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -5887,7 +5876,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3392,10 +3392,14 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
+      if (!req.file) {
+        return sendError(res, 400, "No file attached — include an 'avatar' field in the multipart body");
+      }
+
       const path = `avatars/${username}`;
       const { error: uploadError } = await supabaseClient.storage
         .from(bucket)
-        .upload(path, req.file!.buffer, { upsert: true });
+        .upload(path, req.file.buffer, { upsert: true });
 
       if (uploadError) {
         req.log.error({ err: uploadError }, "supabase storage upload failed");
@@ -3787,18 +3791,30 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
   // ── Recurring Support ───────────────────────────────────────────────────
 
+  const recurringSchema = z.object({
+    profileId:  z.string().min(1),
+    amount:     z.string().regex(/^\d+(\.\d{1,7})?$/, "amount must be a positive decimal with up to 7 decimal places").refine(v => parseFloat(v) > 0, "amount must be greater than zero"),
+    assetCode:  z.string().min(1).max(12).optional().default("XLM"),
+    frequency:  z.enum(["weekly", "monthly"]),
+  });
+
   v1Router.post("/recurring-support", requireAuth, writeLimiter, async (req, res) => {
-    const { profileId, amount, assetCode, frequency } = req.body;
-
-    if (!profileId || !amount || !frequency) {
-      return sendError(res, 400, "profileId, amount, and frequency are required");
+    const parsed = recurringSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendError(res, 400, parsed.error.issues.map(i => i.message).join("; "));
     }
-    if (frequency !== "weekly" && frequency !== "monthly") {
-      return sendError(res, 400, "frequency must be 'weekly' or 'monthly'");
-    }
+    const { profileId, amount, assetCode, frequency } = parsed.data;
 
-    const profile = await prisma.profile.findUnique({ where: { id: profileId } });
+    const profile = await prisma.profile.findUnique({
+      where: { id: profileId },
+      include: { acceptedAssets: true },
+    });
     if (!profile) return sendError(res, 404, "Profile not found");
+
+    const acceptedCodes = profile.acceptedAssets.map((a: { code: string }) => a.code);
+    if (acceptedCodes.length > 0 && !acceptedCodes.includes(assetCode)) {
+      return sendError(res, 400, `Asset '${assetCode}' is not accepted by this profile. Accepted: ${acceptedCodes.join(", ")}`);
+    }
 
     const user = await prisma.user.findFirst({ where: { email: req.auth!.walletAddress } });
     if (!user) return sendError(res, 401, "User not found");
@@ -3815,7 +3831,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         supporterId: user.id,
         profileId,
         amount,
-        assetCode: assetCode ?? "XLM",
+        assetCode,
         frequency,
         nextRunAt,
       },

--- a/backend/src/services/event-indexer.ts
+++ b/backend/src/services/event-indexer.ts
@@ -311,29 +311,27 @@ export class EventIndexer {
 
   private async tick(): Promise<void> {
     if (this.stopped) return;
+    // Process exactly one page per tick so the event loop is never blocked by a
+    // massive backfill. When more pages are available we reschedule with a 0 ms
+    // delay (fast drain) rather than holding all pages in memory simultaneously.
+    let delay = this.pollIntervalMs;
     try {
-      let totalIngested = 0;
-      let pages = 0;
-      // Drain multiple pages per tick so large event histories (backfill)
-      // are processed quickly rather than one page every pollIntervalMs.
-      while (pages < this.maxPagesPerTick) {
-        const { ingested, nextCursor } = await this.pollOnce();
-        totalIngested += ingested;
-        pages++;
-        if (ingested === 0 || nextCursor === null) break;
-      }
-      if (totalIngested > 0) {
+      const { ingested, nextCursor } = await this.pollOnce();
+      if (ingested > 0) {
         logger.info(
-          { ingested: totalIngested, pages, contractId: this.contractId },
+          { ingested, contractId: this.contractId },
           "indexed events",
         );
-        // Resolve orphaned transactions after ingesting new events
         await this.resolveOrphans().catch((err) => {
           logger.warn({ err }, "orphan resolution failed — will retry next tick");
         });
+        // More pages available — re-enter immediately but yield to the event loop.
+        if (nextCursor !== null) delay = 0;
       }
+    } catch (err) {
+      logger.error({ err }, "event indexer tick failed");
     } finally {
-      this.scheduleNextTick(this.pollIntervalMs);
+      this.scheduleNextTick(delay);
     }
   }
 }

--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -7,6 +7,8 @@ import {
   BASE_FEE,
   Horizon,
   TransactionBuilder,
+  Transaction,
+  FeeBumpTransaction,
 } from "@stellar/stellar-sdk";
 import {
   buildSupportIntent,
@@ -71,6 +73,9 @@ export function SupportPanel({
   const [message, setMessage] = useState("");
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState<"weekly" | "monthly">("monthly");
+  const [sending, setSending] = useState(false);
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   const handleCopy = useCallback(async () => {
     try {
@@ -88,6 +93,76 @@ export function SupportPanel({
       handleCopy();
     }
   }, [handleCopy]);
+
+  const handleSend = useCallback(async () => {
+    const parsedAmt = parseFloat(amount);
+    const validAmount = !isNaN(parsedAmt) && parsedAmt > 0;
+    const parsedBal = balance ? parseFloat(balance) : 0;
+    const overBalance = validAmount && parsedAmt + FEE_IN_XLM > parsedBal;
+    if (!visitorAddress || !validAmount || overBalance || sending) return;
+
+    const walletId = (typeof localStorage !== "undefined" ? localStorage.getItem("walletId") : null) as WalletId | null;
+    const adapter = walletId ? getWalletAdapter(walletId) : null;
+    if (!adapter) {
+      showToast("Wallet not connected — please reconnect and try again.", "error");
+      return;
+    }
+
+    setSending(true);
+    try {
+      let xdr: string;
+      const isPathPayment = paymentAsset.code !== "XLM";
+      if (isPathPayment) {
+        const srcAsset = paymentAsset.issuer
+          ? new StellarAsset(paymentAsset.code, paymentAsset.issuer)
+          : StellarAsset.native();
+        xdr = await buildPathPaymentIntent({
+          sourceAccount: visitorAddress,
+          sourceAsset: srcAsset,
+          sourceAmount: amount,
+          destAsset: StellarAsset.native(),
+          destAddress: walletAddress,
+          memo: message || undefined,
+        });
+      } else {
+        xdr = await buildSupportIntent({
+          sourceAccount: visitorAddress,
+          destination: walletAddress,
+          amount,
+          assetCode: paymentAsset.code,
+          assetIssuer: paymentAsset.issuer,
+          memo: message || undefined,
+        });
+      }
+
+      const signedXdr = await adapter.signTransaction(xdr, {
+        networkPassphrase: stellarConfig.networkPassphrase,
+        address: visitorAddress,
+      });
+
+      const tx = TransactionBuilder.fromXDR(signedXdr, stellarConfig.networkPassphrase) as Transaction | FeeBumpTransaction;
+      const result = await horizonServer.submitTransaction(tx);
+      setTxHash(result.hash);
+
+      if (isRecurring && profileId) {
+        await fetch(`${API_BASE_URL}/api/v1/recurring-support`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ profileId, amount, assetCode: paymentAsset.code, frequency }),
+        }).catch(() => {
+          // Non-critical — recurring registration failure doesn't affect the payment.
+        });
+      }
+    } catch (err: unknown) {
+      showToast(mapWalletError(err), "error");
+    } finally {
+      setSending(false);
+    }
+  }, [
+    visitorAddress, amount, balance, sending,
+    paymentAsset, walletAddress, message, isRecurring, profileId, frequency,
+    showToast,
+  ]);
 
   const loadBalance = async (address: string) => {
     if (!address) return;
@@ -497,16 +572,27 @@ export function SupportPanel({
 
       <button
         type="button"
-        disabled={!hasValidAmount || insufficientBalance}
+        onClick={handleSend}
+        disabled={!hasValidAmount || insufficientBalance || sending}
         className="mt-6 w-full rounded-lg bg-mint px-4 py-3 text-sm font-semibold text-black hover:bg-mint/90 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
       >
-        Send Support
+        {sending ? "Sending…" : "Send Support"}
       </button>
 
       <p className="mt-4 text-xs leading-6 text-steel">
         This builds and signs a Stellar payment using Freighter.
         The transaction hash is stored on the NovaSupport backend.
       </p>
+
+      <TransactionResultModal
+        txHash={txHash}
+        amount={amount}
+        assetCode={paymentAsset.code || "XLM"}
+        recipientDisplayName={recipientDisplayName}
+        note={message || null}
+        isOpen={txHash !== null}
+        onClose={() => setTxHash(null)}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- **#579** — Avatar upload `POST /profiles/:username/avatar` now returns 400 with a clear message when no `avatar` file is attached, instead of crashing with a TypeError on `req.file!.buffer`.
- **#578** — Send Support button now has an `onClick` handler that builds the Stellar transaction (direct payment or path payment via DEX), signs it through the connected wallet adapter (Freighter/Albedo/LOBSTR), submits to Horizon, and shows the `TransactionResultModal` with the tx hash. If `isRecurring` is enabled, also registers the recurring support schedule via the backend API. Error toasts are shown on failure.
- **#580** — `POST /v1/recurring-support` now validates through a Zod schema: `amount` must be a positive decimal with up to 7 decimal places, and `assetCode` must be one of the profile's accepted assets (when the profile has any configured). Returns descriptive 400 errors instead of propagating bad values to the drip scheduler.
- **#577** — `EventIndexer.tick()` now processes exactly one page per tick and re-schedules with `0 ms` delay when more pages are available, instead of looping up to 500 pages in a single async execution. A mainnet backfill now holds only ~100 events in memory at a time; the event loop gets to breathe between each page.

## Test plan

- [ ] Upload avatar without attaching a file — confirm 400 with message "No file attached"
- [ ] Upload avatar with a valid image file — confirm upload succeeds and `avatarUrl` is updated
- [ ] Connect wallet, enter an amount, click "Send Support" — confirm Freighter/wallet prompts for signing
- [ ] Confirm successful tx shows `TransactionResultModal` with the tx hash and Stellar Expert link
- [ ] Decline signing in wallet — confirm error toast appears
- [ ] `POST /v1/recurring-support` with `amount: "-5"` — confirm 400 "amount must be greater than zero"
- [ ] `POST /v1/recurring-support` with `assetCode: "UNSUPPORTED"` — confirm 400 listing accepted assets
- [ ] `POST /v1/recurring-support` with valid data — confirm 201 and subscription created
- [ ] Start indexer on a testnet with many historical events — confirm it processes page by page without memory spike

Closes #577 
Closes #578 
Closes #579  
Closes #580 