### PR TITLE
fix: allow dots in GitHub usernames and require issuer for non-XLM as…

### DIFF
--- a/backend/prisma/migrations/20260623000000_add_accepted_asset_issuer_constraint/migration.sql
+++ b/backend/prisma/migrations/20260623000000_add_accepted_asset_issuer_constraint/migration.sql
@@ -1,0 +1,11 @@
+-- #610: Require issuer for all non-XLM accepted assets.
+-- XLM is the native Stellar asset and has no issuer; every other asset
+-- (e.g. USDC, EURC) is identified by both a code AND an issuer address.
+-- Allowing a NULL issuer on a non-XLM row creates an unresolvable asset
+-- reference on the Stellar network.
+--
+-- Application-level validation (Zod refine) was added at the same time,
+-- so this constraint acts as a database-level safety net.
+ALTER TABLE "AcceptedAsset"
+  ADD CONSTRAINT "AcceptedAsset_issuer_required_for_non_xlm"
+  CHECK (UPPER(code) = 'XLM' OR (issuer IS NOT NULL AND issuer <> ''));

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1347,6 +1347,131 @@ async function main() {
     }
   });
 
+  // ── Issue #605: GitHub usernames with dots ────────────────────────────
+
+  // Test 48a: githubUsername with dot should pass regex validation (not return 400)
+  await runTest("POST /profiles/import/github → dotted username (user.name) passes regex validation", async () => {
+    const srv = await startTestServer(makeLogStream().stream);
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      const res = await fetch(`${srv.baseUrl}/profiles/someuser/import/github`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ githubUsername: "user.name" }),
+      });
+      // Validation passes → gets past regex → should NOT be 400 (will be 404 with DB, or non-400 without)
+      assert.notEqual(res.status, 400, `Dotted username should pass regex, but got 400`);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  // Test 48b: githubUsername starting or ending with a dot is still rejected
+  await runTest("POST /profiles/import/github → 400 when githubUsername starts with dot", async () => {
+    const srv = await startTestServer(makeLogStream().stream);
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      const res = await fetch(`${srv.baseUrl}/profiles/someuser/import/github`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ githubUsername: ".leading" }),
+      });
+      assert.equal(res.status, 400, `Expected 400 for username starting with dot, got ${res.status}`);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  // Test 48c: githubUsername ending with a dot is still rejected
+  await runTest("POST /profiles/import/github → 400 when githubUsername ends with dot", async () => {
+    const srv = await startTestServer(makeLogStream().stream);
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      const res = await fetch(`${srv.baseUrl}/profiles/someuser/import/github`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ githubUsername: "trailing." }),
+      });
+      assert.equal(res.status, 400, `Expected 400 for username ending with dot, got ${res.status}`);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  // ── Issue #610: Non-XLM asset issuer validation ───────────────────────
+
+  // Test 48d: PATCH /profiles/:username/assets → 422 when non-XLM asset is missing issuer
+  await runTest("PATCH /profiles/:username/assets → 422 when non-XLM asset has no issuer", async () => {
+    const srv = await startTestServer(makeLogStream().stream);
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      const res = await fetch(`${srv.baseUrl}/profiles/anyuser/assets`, {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ assets: [{ code: "USDC" }] }),
+      });
+      assert.equal(res.status, 422, `Expected 422 for USDC without issuer, got ${res.status}`);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  // Test 48e: PATCH /profiles/:username/assets → XLM without issuer is still accepted by validation
+  await runTest("PATCH /profiles/:username/assets → XLM without issuer passes schema validation", async () => {
+    const srv = await startTestServer(makeLogStream().stream);
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      const res = await fetch(`${srv.baseUrl}/profiles/anyuser/assets`, {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ assets: [{ code: "XLM" }] }),
+      });
+      // Validation passes for XLM → not 422; subsequent steps (auth/DB) may differ
+      assert.notEqual(res.status, 422, `XLM without issuer should pass schema validation but got 422`);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  // Test 48f: POST /profiles → 400 when a non-XLM accepted asset is missing its issuer
+  await runTest("POST /profiles → 400 when non-XLM acceptedAsset is missing issuer", async () => {
+    const srv = await startTestServer(makeLogStream().stream);
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      const res = await fetch(`${srv.baseUrl}/profiles`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          username: "testuser",
+          displayName: "Test",
+          walletAddress,
+          acceptedAssets: [{ code: "USDC" }],
+        }),
+      });
+      assert.equal(res.status, 400, `Expected 400 for USDC without issuer, got ${res.status}`);
+    } finally {
+      await srv.close();
+    }
+  });
+
   if (hasDb) {
     // Test 49: POST /profiles/import/github → 404 when NovaSupport profile not found
     await runTest("POST /profiles/import/github → 404 when profile not found", async () => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1380,16 +1380,23 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     githubHandle: z
       .string()
       .max(39)
-      .regex(/^[a-zA-Z0-9-]+$/)
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9.-]{0,37}[a-zA-Z0-9]$/)
       .optional()
       .nullable(),
     // ownerId removed - now derived from JWT
     acceptedAssets: z
       .array(
-        z.object({
-          code: z.string().min(1).max(12),
-          issuer: z.string().optional(),
-        }),
+        z
+          .object({
+            code: z.string().min(1).max(12),
+            issuer: z.string().optional(),
+          })
+          .refine(
+            (asset) =>
+              asset.code.toUpperCase() === "XLM" ||
+              (typeof asset.issuer === "string" && asset.issuer.trim().length > 0),
+            { message: "issuer is required for non-XLM assets" },
+          ),
       )
       .min(1),
   });
@@ -1643,7 +1650,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     githubHandle: z
       .string()
       .max(39)
-      .regex(/^[a-zA-Z0-9-]+$/)
+      .regex(/^[a-zA-Z0-9][a-zA-Z0-9.-]{0,37}[a-zA-Z0-9]$/)
       .optional()
       .nullable(),
   });
@@ -1892,13 +1899,13 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     writeLimiter,
     async (req, res) => {
       const importSchema = z.object({
-        githubUsername: z.string().min(1).max(39).regex(/^[a-zA-Z0-9-]+$/),
+        githubUsername: z.string().min(2).max(39).regex(/^[a-zA-Z0-9][a-zA-Z0-9.-]{0,37}[a-zA-Z0-9]$/),
         githubToken: z.string().optional(),
       });
 
       const parsed = importSchema.safeParse(req.body);
       if (!parsed.success) {
-        return sendError(res, 400, "githubUsername is required (1–39 alphanumeric/hyphen chars)");
+        return sendError(res, 400, "githubUsername is required (2–39 chars: alphanumeric, hyphens, or dots; must start and end with alphanumeric)");
       }
 
       const { githubUsername, githubToken } = parsed.data;
@@ -2112,10 +2119,17 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   const updateAssetsSchema = z.object({
     assets: z
       .array(
-        z.object({
-          code: z.string().regex(/^[A-Z]{1,12}$/),
-          issuer: z.string().optional(),
-        }),
+        z
+          .object({
+            code: z.string().regex(/^[A-Z]{1,12}$/),
+            issuer: z.string().optional(),
+          })
+          .refine(
+            (asset) =>
+              asset.code === "XLM" ||
+              (typeof asset.issuer === "string" && asset.issuer.trim().length > 0),
+            { message: "issuer is required for non-XLM assets" },
+          ),
       )
       .min(1),
   });

--- a/backend/src/middleware/sanitize.ts
+++ b/backend/src/middleware/sanitize.ts
@@ -172,12 +172,12 @@ function sanitizeSocialHandle(platform: string, handle: string): SanitizationRes
       break;
       
     case "githubHandle":
-      // GitHub handles: 1-39 characters, alphanumeric + hyphens, can't start/end with hyphen
-      if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/.test(result)) {
-        violations.push("GitHub handle must be 1-39 characters, letters, numbers, hyphens (not at start/end)");
-        result = result.replace(/[^a-zA-Z0-9-]/g, "").slice(0, 39);
-        // Remove leading/trailing hyphens
-        result = result.replace(/^-+|-+$/g, "");
+      // GitHub handles: 1-39 characters, alphanumeric + hyphens + dots, can't start/end with hyphen or dot
+      if (!/^[a-zA-Z0-9]([a-zA-Z0-9.-]{0,37}[a-zA-Z0-9])?$/.test(result)) {
+        violations.push("GitHub handle must be 1-39 characters, letters, numbers, hyphens, or dots (not at start/end)");
+        result = result.replace(/[^a-zA-Z0-9.-]/g, "").slice(0, 39);
+        // Remove leading/trailing hyphens or dots
+        result = result.replace(/^[-.]+|[-.]+$/g, "");
       }
       break;
       


### PR DESCRIPTION
 The import endpoint and profile schemas rejected valid GitHub usernames containing dots (e.g. user.name). Updated regex from /^[a-zA-Z0-9-]+$/ to /^[a-zA-Z0-9][a-zA-Z0-9.-]{0,37}[a-zA-Z0-9]$/ across all three Zod validators (create profile, update profile, import endpoint) and the sanitize middleware, matching GitHub's actual username spec.

 AcceptedAsset.issuer was nullable with no guard, allowing ambiguous non-XLM assets (e.g. USDC with no issuer) that cannot be resolved on the Stellar network. Added a .refine() check in both the create-profile and update-assets Zod schemas that rejects any asset where code != 'XLM' and issuer is absent or blank. A companion database CHECK constraint is added via migration as a safety net.

closes #605
closes #610
