### PR TITLE
fix: partial index on WebhookDelivery pending rows and RecurringSuppo…

### DIFF
--- a/backend/prisma/migrations/20260623010000_add_webhook_delivery_partial_index/migration.sql
+++ b/backend/prisma/migrations/20260623010000_add_webhook_delivery_partial_index/migration.sql
@@ -1,0 +1,14 @@
+-- #609: Add a partial index on WebhookDelivery for status = 'pending'.
+--
+-- The webhook processor queries:
+--   WHERE status = 'pending' AND nextRetryAt <= now AND attemptCount < 3
+--
+-- The existing composite index (status, nextRetryAt) covers every status value,
+-- so as completed and failed rows accumulate over time the index grows
+-- unboundedly and the processor scan stays slow.
+--
+-- This partial index contains only pending rows, keeping it small and ensuring
+-- the processor query is fast regardless of how large the delivery history grows.
+CREATE INDEX "WebhookDelivery_pending_nextRetryAt_idx"
+    ON "WebhookDelivery" ("nextRetryAt")
+    WHERE (status = 'pending');

--- a/backend/prisma/migrations/20260623020000_recurring_support_set_null_soft_delete/migration.sql
+++ b/backend/prisma/migrations/20260623020000_recurring_support_set_null_soft_delete/migration.sql
@@ -1,0 +1,31 @@
+-- #608: Replace cascade delete on RecurringSupport.supporterId with SET NULL
+--       and add a soft-delete timestamp column.
+--
+-- Previously, deleting a User cascaded to all their RecurringSupport rows,
+-- permanently erasing subscription history with no recovery path and no
+-- notification reaching creators whose active subscriptions were silently
+-- cancelled.
+--
+-- With SET NULL:
+--   - The RecurringSupport row is preserved when the supporter's User row
+--     is deleted. supporterId becomes NULL.
+--   - Application code (drip-scheduler) detects a NULL supporterId on the
+--     next processing run and writes status = 'cancelled' + cancelledAt = now(),
+--     giving creators a visible record of the cancellation.
+
+-- 1. Allow supporterId to be NULL (reverting the NOT NULL added in
+--    20260531000000_fix_recurring_support_supporter_id).
+ALTER TABLE "RecurringSupport" ALTER COLUMN "supporterId" DROP NOT NULL;
+
+-- 2. Add soft-delete timestamp so application code can record when the
+--    subscription was implicitly cancelled by account deletion.
+ALTER TABLE "RecurringSupport" ADD COLUMN "cancelledAt" TIMESTAMP(3);
+
+-- 3. Swap the CASCADE foreign key for SET NULL.
+ALTER TABLE "RecurringSupport"
+    DROP CONSTRAINT "RecurringSupport_supporterId_fkey";
+
+ALTER TABLE "RecurringSupport"
+    ADD CONSTRAINT "RecurringSupport_supporterId_fkey"
+    FOREIGN KEY ("supporterId") REFERENCES "User"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -171,21 +171,29 @@ model WebhookDelivery {
 
   @@index([webhookId])
   @@index([status, nextRetryAt])
+  // #609: A partial index covering only status = 'pending' rows is created via
+  // a raw migration (20260623010000) because Prisma's DSL does not support
+  // partial indexes. That index keeps the webhook processor query fast as
+  // completed/failed history accumulates.
 }
 
 model RecurringSupport {
-  id          String   @id @default(cuid())
-  supporterId String
+  id          String    @id @default(cuid())
+  supporterId String?
   profileId   String
-  amount      Decimal  @db.Decimal(18, 7)
-  assetCode   String   @default("XLM")
+  amount      Decimal   @db.Decimal(18, 7)
+  assetCode   String    @default("XLM")
   frequency   String
-  nextRunAt   DateTime @default(now())
-  status      String   @default("active")
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  supporter   User     @relation("RecurringSupporters", fields: [supporterId], references: [id], onDelete: Cascade)
-  profile     Profile  @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  nextRunAt   DateTime  @default(now())
+  status      String    @default("active")
+  cancelledAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  // #608: onDelete: SetNull preserves subscription history when the supporter's
+  // User row is deleted. supporterId becomes NULL; the drip-scheduler detects
+  // this on its next run and writes status = 'cancelled' + cancelledAt.
+  supporter   User?     @relation("RecurringSupporters", fields: [supporterId], references: [id], onDelete: SetNull)
+  profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
 
   @@index([supporterId])
   @@index([profileId])

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3874,12 +3874,13 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
       return res.json(subscriptions.map((s) => ({
         id: s.id,
-        supporterAddress: s.supporter.email,
+        supporterAddress: s.supporter?.email ?? null,
         amount: s.amount.toString(),
         assetCode: s.assetCode,
         frequency: s.frequency,
         nextRunAt: s.nextRunAt,
         status: s.status,
+        cancelledAt: s.cancelledAt,
         createdAt: s.createdAt,
       })));
     }

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -30,6 +30,7 @@ export async function processDueRecurringSupports() {
     }
 
     try {
+      const supporter = support.supporter;
       // Calculate nextRunAt based on frequency
       const nextRunAt = new Date(now);
       if (support.frequency === "weekly") {
@@ -42,7 +43,7 @@ export async function processDueRecurringSupports() {
       await prisma.$transaction(async (tx: any) => {
         // Create the pending SupportTransaction
         const txHash = `pending_${crypto.randomUUID()}`;
-        
+
         await tx.supportTransaction.create({
           data: {
             txHash,
@@ -54,7 +55,7 @@ export async function processDueRecurringSupports() {
             recipientAddress: support.profile.walletAddress,
             profileId: support.profileId,
             supporterId: support.supporterId,
-            supporterAddress: support.supporter.email,
+            supporterAddress: supporter.email,
           },
         });
 

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -17,6 +17,18 @@ export async function processDueRecurringSupports() {
   });
 
   for (const support of dueSupports) {
+    // #608: supporterId is NULL when the supporter's account was deleted (SET NULL FK).
+    // Mark the subscription cancelled so it stops appearing as due and so
+    // the profile owner can see the cancellation in their dashboard.
+    if (!support.supporter) {
+      await prisma.recurringSupport.update({
+        where: { id: support.id },
+        data: { status: "cancelled", cancelledAt: new Date() },
+      });
+      logger.info({ dripId: support.id, profileId: support.profileId }, "Recurring support cancelled: supporter account deleted");
+      continue;
+    }
+
     try {
       // Calculate nextRunAt based on frequency
       const nextRunAt = new Date(now);


### PR DESCRIPTION

 — adds a PostgreSQL partial index on WebhookDelivery(nextRetryAt) WHERE status = 'pending' via a raw migration. The webhook processor only ever reads pending rows; the existing composite index over all statuses would grow unboundedly as completed/failed history accumulated.

 — replaces the cascade delete on RecurringSupport.supporterId with SET NULL and adds a cancelledAt soft-delete column. Deleting a User no longer silently destroys subscription history. The drip-scheduler detects a NULL supporterId on its next run and writes status = 'cancelled' + cancelledAt so creators can see when an active subscription was cancelled by account deletion.
Closes #608
Closes #609
