### PR TITLE
Fix/issues 597 604

### DIFF
--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -1172,6 +1172,55 @@ async function main() {
     }
   });
 
+  // ── Issue #604: SKIP_HORIZON_VALIDATION warn log ─────────────────────
+
+  // Test 42a: SKIP_HORIZON_VALIDATION=true logs a WARN at each bypass
+  await runTest("POST /support-transactions → WARN logged when SKIP_HORIZON_VALIDATION=true", async () => {
+    const { stream, getOutput } = makeLogStream();
+    const srv = await startTestServer(stream);
+    const prev = process.env.SKIP_HORIZON_VALIDATION;
+    process.env.SKIP_HORIZON_VALIDATION = "true";
+
+    try {
+      const token = signJWT(walletAddress, "fake-user-id");
+      // Send a well-formed request so it passes validation and reaches the bypass check.
+      // Without a DB the request will ultimately fail, but the WARN is emitted first.
+      await fetch(`${srv.baseUrl}/support-transactions`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          txHash: `skip-test-${randomUUID()}`,
+          amount: "1.0000000",
+          assetCode: "XLM",
+          recipientAddress: walletAddress,
+          profileId: "fake-profile-id",
+          stellarNetwork: "TESTNET",
+        }),
+      });
+
+      await new Promise((r) => setImmediate(r));
+
+      const lines = parseLogLines(getOutput());
+      const warnEntry = lines.find(
+        (l) =>
+          l.level === 40 &&
+          typeof l.msg === "string" &&
+          (l.msg as string).includes("SKIP_HORIZON_VALIDATION is enabled"),
+      );
+      assert.ok(
+        warnEntry !== undefined,
+        `Expected a WARN log for SKIP_HORIZON_VALIDATION bypass. Got:\n${getOutput()}`,
+      );
+    } finally {
+      await srv.close();
+      if (prev === undefined) delete process.env.SKIP_HORIZON_VALIDATION;
+      else process.env.SKIP_HORIZON_VALIDATION = prev;
+    }
+  });
+
   // ── Issue #447: Leaderboard caching ──────────────────────────────────
   if (hasDb) {
     // Test 43: GET /profiles/:username/leaderboard → returns correct structure

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2945,10 +2945,17 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         assetIssuer: parsed.data.assetIssuer,
       };
 
-      const verification =
-        process.env.SKIP_HORIZON_VALIDATION === "true"
-          ? true
-          : await verifyTransaction(parsed.data.txHash, 3, 1000, req, expectedDetails);
+      const skipHorizonValidation = process.env.SKIP_HORIZON_VALIDATION === "true";
+      if (skipHorizonValidation) {
+        req.log.warn(
+          { txHash: parsed.data.txHash },
+          "SKIP_HORIZON_VALIDATION is enabled — transaction verification bypassed",
+        );
+      }
+
+      const verification = skipHorizonValidation
+        ? true
+        : await verifyTransaction(parsed.data.txHash, 3, 1000, req, expectedDetails);
 
       if (verification === false) {
         return res

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -91,6 +91,12 @@ if (startupConfig.horizonUrl.includes("testnet")) {
   );
 }
 
+if (process.env.SKIP_HORIZON_VALIDATION === "true") {
+  logger.warn(
+    "SKIP_HORIZON_VALIDATION is enabled — transaction verification bypassed",
+  );
+}
+
 import { app } from "./app.js";
 import { startDripScheduler } from "./services/drip-scheduler.js";
 import { startWebhookProcessor } from "./services/webhook-processor.js";

--- a/frontend/src/components/__tests__/additional-snapshots.test.tsx
+++ b/frontend/src/components/__tests__/additional-snapshots.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from "vitest";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { ThemeToggle } from "../theme-toggle";
 import { MilestoneCard } from "../milestone-card";
 import { EmbedWidget } from "../embed-widget";
@@ -20,6 +20,7 @@ vi.mock("lucide-react", () => ({
   RefreshCw: () => <span>RefreshCw</span>,
   ChevronDown: () => <span>ChevronDown</span>,
   Loader2: () => <span>Loader2</span>,
+  AlertTriangle: () => <span>AlertTriangle</span>,
   Trophy: () => <span>Trophy</span>,
   Target: () => <span>Target</span>,
   Sparkles: () => <span>Sparkles</span>,
@@ -142,5 +143,27 @@ describe("Additional Component Snapshots", () => {
   it("NotificationPreferences matches snapshot (no auth token)", () => {
     const { container } = render(<NotificationPreferences username="johndoe" />);
     expect(container).toMatchSnapshot();
+  });
+
+  // Issue #597: milestones fetch failure shows a partial-failure notice
+  it("ActivityFeed shows partial-failure notice when milestones fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ transactions: [] }),
+        } as unknown as Response)
+        .mockRejectedValueOnce(new Error("Network error")),
+    );
+
+    const { container } = render(<ActivityFeed username="johndoe" limit={5} />);
+
+    await waitFor(() => {
+      expect(container.textContent).toContain("Milestone data could not be loaded");
+    });
+
+    // Restore the original never-resolving mock for subsequent tests
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
   });
 });

--- a/frontend/src/components/activity-feed.tsx
+++ b/frontend/src/components/activity-feed.tsx
@@ -8,6 +8,7 @@ import {
   RefreshCw,
   ChevronDown,
   Loader2,
+  AlertTriangle,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
@@ -77,6 +78,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
   const [activities, setActivities] = useState<ActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [milestonesUnavailable, setMilestonesUnavailable] = useState(false);
   const [displayedItems, setDisplayedItems] = useState(limit);
   const [hasMore, setHasMore] = useState(false);
 
@@ -88,6 +90,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
     try {
       setLoading(true);
       setError(null);
+      setMilestonesUnavailable(false);
 
       const [transactionsRes, milestonesRes] = await Promise.all([
         fetch(`${API_BASE_URL}/profiles/${username}/transactions?limit=100`),
@@ -97,8 +100,13 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
       const transactionsData = transactionsRes.ok
         ? await transactionsRes.json()
         : { transactions: [] };
-      const milestonesData = milestonesRes?.ok
-        ? await milestonesRes.json()
+
+      const milestonesOk = milestonesRes?.ok === true;
+      if (!milestonesOk) {
+        setMilestonesUnavailable(true);
+      }
+      const milestonesData = milestonesOk
+        ? await milestonesRes!.json()
         : { milestones: [] };
 
       const items: ActivityItem[] = [];
@@ -181,88 +189,102 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
     );
   }
 
-  if (activities.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <TrendingUp className="h-12 w-12 text-white/20 mx-auto mb-4" />
-        <p className="text-white/50">No activity yet</p>
-      </div>
-    );
-  }
-
   const visibleActivities = activities.slice(0, displayedItems);
   const remainingCount = Math.max(0, activities.length - displayedItems);
 
   return (
     <div className="space-y-3">
-      <AnimatePresence>
-        {visibleActivities.map((activity, index) => (
-          <motion.div
-            key={activity.id}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -10 }}
-            transition={{ delay: index * 0.05 }}
-            className="group relative rounded-xl border border-white/10 bg-white/5 p-4 transition hover:bg-white/10 hover:border-white/20"
+      {/* Partial-failure notice: milestones API failed but transactions loaded */}
+      {milestonesUnavailable && (
+        <div className="flex items-center gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/10 px-4 py-2 text-sm text-yellow-400">
+          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+          <span>Milestone data could not be loaded — the feed may be incomplete.</span>
+          <button
+            onClick={fetchActivities}
+            className="ml-auto flex-shrink-0 text-xs underline underline-offset-2 hover:text-yellow-300 transition"
           >
-            <div className="flex gap-4">
-              {/* Icon */}
-              <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-white/5">
-                {activity.icon}
-              </div>
+            Retry
+          </button>
+        </div>
+      )}
 
-              {/* Content */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-start justify-between gap-2 mb-1">
-                  <h3 className="font-semibold text-white text-sm truncate">
-                    {activity.title}
-                  </h3>
-                  <span className="flex-shrink-0 text-xs text-white/50 whitespace-nowrap">
-                    {formatDate(activity.timestamp)}
-                  </span>
-                </div>
+      {activities.length === 0 ? (
+        <div className="text-center py-12">
+          <TrendingUp className="h-12 w-12 text-white/20 mx-auto mb-4" />
+          <p className="text-white/50">No activity yet</p>
+        </div>
+      ) : (
+        <>
+          <AnimatePresence>
+            {visibleActivities.map((activity, index) => (
+              <motion.div
+                key={activity.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ delay: index * 0.05 }}
+                className="group relative rounded-xl border border-white/10 bg-white/5 p-4 transition hover:bg-white/10 hover:border-white/20"
+              >
+                <div className="flex gap-4">
+                  {/* Icon */}
+                  <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-white/5">
+                    {activity.icon}
+                  </div>
 
-                <p className="text-xs text-white/60 mb-3">{activity.description}</p>
-
-                {/* Metadata */}
-                {activity.metadata && (
-                  <div className="flex flex-wrap gap-2">
-                    {activity.metadata.amount && (
-                      <span className="inline-flex items-center gap-1 px-2 py-1 rounded bg-mint/10 text-xs text-mint font-mono">
-                        {activity.metadata.amount} {activity.metadata.assetCode}
+                  {/* Content */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2 mb-1">
+                      <h3 className="font-semibold text-white text-sm truncate">
+                        {activity.title}
+                      </h3>
+                      <span className="flex-shrink-0 text-xs text-white/50 whitespace-nowrap">
+                        {formatDate(activity.timestamp)}
                       </span>
-                    )}
-                    {activity.metadata.txHash && (
-                      <Link
-                        href={`https://stellar.expert/explorer/testnet/tx/${activity.metadata.txHash}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 px-2 py-1 rounded bg-white/5 text-xs text-white/70 hover:text-white/90 transition font-mono"
-                      >
-                        {truncateHash(activity.metadata.txHash)}
-                        <span>↗</span>
-                      </Link>
+                    </div>
+
+                    <p className="text-xs text-white/60 mb-3">{activity.description}</p>
+
+                    {/* Metadata */}
+                    {activity.metadata && (
+                      <div className="flex flex-wrap gap-2">
+                        {activity.metadata.amount && (
+                          <span className="inline-flex items-center gap-1 px-2 py-1 rounded bg-mint/10 text-xs text-mint font-mono">
+                            {activity.metadata.amount} {activity.metadata.assetCode}
+                          </span>
+                        )}
+                        {activity.metadata.txHash && (
+                          <Link
+                            href={`https://stellar.expert/explorer/testnet/tx/${activity.metadata.txHash}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 px-2 py-1 rounded bg-white/5 text-xs text-white/70 hover:text-white/90 transition font-mono"
+                          >
+                            {truncateHash(activity.metadata.txHash)}
+                            <span>↗</span>
+                          </Link>
+                        )}
+                      </div>
                     )}
                   </div>
-                )}
-              </div>
-            </div>
-          </motion.div>
-        ))}
-      </AnimatePresence>
+                </div>
+              </motion.div>
+            ))}
+          </AnimatePresence>
 
-      {/* Load more button */}
-      {remainingCount > 0 && (
-        <motion.button
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          onClick={() => setDisplayedItems((prev) => prev + limit)}
-          className="w-full mt-4 py-3 rounded-lg border border-white/10 bg-white/5 text-sm font-medium text-white transition hover:bg-white/10 hover:border-white/20 flex items-center justify-center gap-2"
-        >
-          Load more
-          <ChevronDown size={16} />
-          <span className="text-xs text-white/60">({remainingCount} more)</span>
-        </motion.button>
+          {/* Load more button */}
+          {remainingCount > 0 && (
+            <motion.button
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              onClick={() => setDisplayedItems((prev) => prev + limit)}
+              className="w-full mt-4 py-3 rounded-lg border border-white/10 bg-white/5 text-sm font-medium text-white transition hover:bg-white/10 hover:border-white/20 flex items-center justify-center gap-2"
+            >
+              Load more
+              <ChevronDown size={16} />
+              <span className="text-xs text-white/60">({remainingCount} more)</span>
+            </motion.button>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
fix: surface milestone fetch failures in ActivityFeed and warn on SKIP_HORIZON_VALIDATION

Fixes #597 and #604.

— ActivityFeed silently renders stale data when milestones API fails

The milestones fetch used .catch(() => null) which treated any network or
HTTP error as "no milestones". The feed would render as if milestones simply
didn't exist with no indication that data was missing.

Changes:
- Added milestonesUnavailable state in ActivityFeed, reset on every fetch attempt
- After Promise.all, flags failure when milestonesRes is null (network error)
  or milestonesRes.ok is false (HTTP error)
- Removed the empty-state early return and unified into one render block so
  the banner can appear alongside both the activity list and the empty state
- Shows a yellow partial-failure banner: "Milestone data could not be loaded
  — the feed may be incomplete." with a Retry button that re-runs fetchActivities
- Added AlertTriangle to the lucide-react import and updated the vitest mock
SKIP_HORIZON_VALIDATION=true produced no log trace

When this env var was set to bypass Horizon transaction verification, no log
was written. An operator who accidentally left it enabled in production would
have no way to detect it from logs.

Changes:
- index.ts: emits logger.warn at startup if SKIP_HORIZON_VALIDATION=true,
  consistent with the existing JWT/SMTP/Supabase startup checks
- app.ts: emits req.log.warn at each bypass use, including the txHash, so
  every bypassed transaction is traceable in the log

## Tests

- Frontend: async test mocks transactions fetch to succeed and milestones fetch
  to reject, then asserts the partial-failure banner text appears in the DOM
- Backend: test sets SKIP_HORIZON_VALIDATION=true, sends a well-formed
  authenticated request, and asserts a level-40 WARN containing
  "SKIP_HORIZON_VALIDATION is enabled" appears in the captured log stream
  
  closes #604 
  closes #597 