### PR TITLE
fix: tie milestone progress to SUCCESS transactions and add wallet em…

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3003,27 +3003,29 @@ All errors return JSON with an \`error\` field and optional \`code\`:
             data: parsed.data,
           });
 
-          const milestones = await tx.milestone.findMany({
-            where: {
-              profileId: parsed.data.profileId,
-              assetCode: parsed.data.assetCode,
-              status: "active",
-            },
-          });
-
-          for (const milestone of milestones) {
-            const updated = await tx.milestone.update({
-              where: { id: milestone.id },
-              data: {
-                currentAmount: { increment: parsed.data.amount },
+          if (parsed.data.status === "SUCCESS") {
+            const milestones = await tx.milestone.findMany({
+              where: {
+                profileId: parsed.data.profileId,
+                assetCode: parsed.data.assetCode,
+                status: "active",
               },
             });
 
-            if (Number(updated.currentAmount) >= Number(updated.targetAmount)) {
-              await tx.milestone.update({
+            for (const milestone of milestones) {
+              const updated = await tx.milestone.update({
                 where: { id: milestone.id },
-                data: { status: "reached" },
+                data: {
+                  currentAmount: { increment: parsed.data.amount },
+                },
               });
+
+              if (Number(updated.currentAmount) >= Number(updated.targetAmount)) {
+                await tx.milestone.update({
+                  where: { id: milestone.id },
+                  data: { status: "reached" },
+                });
+              }
             }
           }
 

--- a/frontend/src/components/support-panel.test.tsx
+++ b/frontend/src/components/support-panel.test.tsx
@@ -16,6 +16,10 @@ vi.mock('@stellar/stellar-sdk', () => ({
   Asset: {
     native: vi.fn(() => ({ type: 'native' })),
   },
+  BASE_FEE: '100',
+  Horizon: {},
+  Transaction: vi.fn(),
+  FeeBumpTransaction: vi.fn(),
   TransactionBuilder: {
     fromXDR: vi.fn(() => ({ mocked: true })),
   },
@@ -182,6 +186,19 @@ describe('SupportPanel', () => {
     render(<SupportPanel {...mockProps} />);
     await waitFor(() => expect(screen.getByText('Pay with')).toBeInTheDocument());
     expect(screen.getByText('Amount')).toBeInTheDocument();
+  });
+
+  it('shows empty wallet message when connected wallet has no balances', async () => {
+    vi.mocked(horizonServer.loadAccount).mockResolvedValue({
+      balances: [],
+    } as never);
+
+    render(<SupportPanel {...mockProps} />);
+    await waitFor(() =>
+      expect(
+        screen.getByText('Your wallet has no supported assets. Fund your wallet to continue.'),
+      ).toBeInTheDocument(),
+    );
   });
 
   it('renders recurring support toggle', async () => {

--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -68,6 +68,7 @@ export function SupportPanel({
   const [copied, setCopied] = useState(false);
   const [paymentAsset, setPaymentAsset] = useState<{ code: string; issuer?: string }>({ code: "XLM" });
   const [visitorBalances, setVisitorBalances] = useState<any[]>([]);
+  const [visitorBalancesLoaded, setVisitorBalancesLoaded] = useState(false);
   const [estimatedReceived, setEstimatedReceived] = useState<string | null>(null);
   const [noPathFound, setNoPathFound] = useState(false);
   const [message, setMessage] = useState("");
@@ -206,6 +207,8 @@ export function SupportPanel({
         setVisitorBalances(account.balances as any[]);
       } catch {
         setVisitorBalances([]);
+      } finally {
+        setVisitorBalancesLoaded(true);
       }
     }
     fetchBalances();
@@ -300,45 +303,51 @@ export function SupportPanel({
           >
             Pay with
           </label>
-          <select
-            id={paymentAssetSelectId}
-            aria-label="Payment asset"
-            value={
-              paymentAsset
-                ? paymentAsset.code === "XLM"
-                  ? "native"
-                  : `${paymentAsset.code}:${paymentAsset.issuer}`
-                : ""
-            }
-            onChange={(e) => {
-              const val = e.target.value;
-              if (val === "native") setPaymentAsset({ code: "XLM" });
-              else {
-                const [code, issuer] = val.split(":");
-                setPaymentAsset({ code, issuer });
+          {visitorBalancesLoaded && visitorBalances.length === 0 ? (
+            <p className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-sky/60">
+              Your wallet has no supported assets. Fund your wallet to continue.
+            </p>
+          ) : (
+            <select
+              id={paymentAssetSelectId}
+              aria-label="Payment asset"
+              value={
+                paymentAsset
+                  ? paymentAsset.code === "XLM"
+                    ? "native"
+                    : `${paymentAsset.code}:${paymentAsset.issuer}`
+                  : ""
               }
-            }}
-            className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-mint/50 focus:outline-none appearance-none"
-          >
-            {visitorBalances.map((b: any) => (
-              <option
-                key={
-                  b.asset_type === "native"
-                    ? "native"
-                    : `${b.asset_code}:${b.asset_issuer}`
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val === "native") setPaymentAsset({ code: "XLM" });
+                else {
+                  const [code, issuer] = val.split(":");
+                  setPaymentAsset({ code, issuer });
                 }
-                value={
-                  b.asset_type === "native"
-                    ? "native"
-                    : `${b.asset_code}:${b.asset_issuer}`
-                }
-                className="bg-ink text-white"
-              >
-                {b.asset_type === "native" ? "XLM" : b.asset_code} (
-                {parseFloat(b.balance).toFixed(2)})
-              </option>
-            ))}
-          </select>
+              }}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white focus:border-mint/50 focus:outline-none appearance-none"
+            >
+              {visitorBalances.map((b: any) => (
+                <option
+                  key={
+                    b.asset_type === "native"
+                      ? "native"
+                      : `${b.asset_code}:${b.asset_issuer}`
+                  }
+                  value={
+                    b.asset_type === "native"
+                      ? "native"
+                      : `${b.asset_code}:${b.asset_issuer}`
+                  }
+                  className="bg-ink text-white"
+                >
+                  {b.asset_type === "native" ? "XLM" : b.asset_code} (
+                  {parseFloat(b.balance).toFixed(2)})
+                </option>
+              ))}
+            </select>
+          )}
         </div>
 
         {/* Amount Input */}


### PR DESCRIPTION

Closes #607: milestone currentAmount was incremented unconditionally on every support transaction regardless of status. Goals could falsely appear reached based on pending, failed, or reversed transactions. The milestone increment block is now guarded by a status === 'SUCCESS' check, so only settled, verified transactions contribute to progress.

Closes #595: when a Freighter wallet is connected but holds no funded assets, the payment asset <select> rendered empty with no explanation. Tracks a visitorBalancesLoaded flag set after the Horizon account fetch resolves, and renders an explicit message — "Your wallet has no supported assets. Fund your wallet to continue." — in place of the selector when the wallet is confirmed empty.

Also adds a missing BASE_FEE export to the @stellar/stellar-sdk mock in support-panel.test.tsx so the test suite can load the component, and adds a test case that asserts the empty-wallet message is shown when loadAccount returns zero balances.
