### PR TITLE
fix: explicit Decimal conversion for milestone increment and global 4…

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,7 @@ import compression from "compression";
 import nodemailer from "nodemailer";
 import { prisma } from "./db.js";
 import { Prisma } from "@prisma/client";
+import { Decimal } from "@prisma/client/runtime/library";
 import { logger } from "./logger.js";
 import {
   generateChallenge,
@@ -3016,7 +3017,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
               const updated = await tx.milestone.update({
                 where: { id: milestone.id },
                 data: {
-                  currentAmount: { increment: parsed.data.amount },
+                  currentAmount: { increment: new Decimal(parsed.data.amount) },
                 },
               });
 

--- a/frontend/src/app/dashboard/[campaignId]/page.tsx
+++ b/frontend/src/app/dashboard/[campaignId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { AppShell } from "@/components/app-shell";
 import { API_BASE_URL } from "@/lib/config";
+import { apiFetch } from "@/lib/api-client";
 import { stellarExpertUrl } from "@/lib/stellar";
 import { 
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -444,14 +445,11 @@ export default function DashboardPage() {
     async function fetchDrips() {
       setDripsLoading(true);
       try {
-        const token = typeof window !== "undefined" ? localStorage.getItem("authToken") : null;
         const endpoint = isOwner
           ? `${API_BASE_URL}/recurring-support?profileId=${campaignId}`
           : `${API_BASE_URL}/recurring-support`;
 
-        const res = await fetch(endpoint, {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-        });
+        const res = await apiFetch(endpoint);
 
         if (!cancelled) {
           if (res.ok) {
@@ -476,13 +474,9 @@ export default function DashboardPage() {
   async function handleDripAction(id: string, action: "paused" | "cancelled") {
     setDripActionLoading(id);
     try {
-      const token = typeof window !== "undefined" ? localStorage.getItem("authToken") : null;
-      const res = await fetch(`${API_BASE_URL}/recurring-support/${id}`, {
+      const res = await apiFetch(`${API_BASE_URL}/recurring-support/${id}`, {
         method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: action }),
       });
       if (res.ok) {
@@ -546,12 +540,8 @@ export default function DashboardPage() {
     setResendingVerification(true);
     setVerificationBannerMsg(null);
     try {
-      const token = typeof window !== "undefined" ? localStorage.getItem("authToken") : null;
-      const res = await fetch(`${API_BASE_URL}/profiles/${campaignId}/resend-verification-email`, {
+      const res = await apiFetch(`${API_BASE_URL}/profiles/${campaignId}/resend-verification-email`, {
         method: "POST",
-        headers: {
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
       });
       const json = await res.json().catch(() => ({})) as Record<string, unknown>;
       if (res.ok) {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { motion } from "framer-motion";
 import { formatRateLimitedMessage, parseRateLimitInfo } from "@/lib/rate-limit";
+import { apiFetch } from "@/lib/api-client";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
 
@@ -309,12 +310,7 @@ export default function DashboardPage() {
     if (!username) return;
     setCsvLoading(true);
     try {
-      const token = localStorage.getItem("authToken");
-      const res = await fetch(`${API_BASE_URL}/profiles/${username}/transactions/export`, {
-        headers: {
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-      });
+      const res = await apiFetch(`${API_BASE_URL}/profiles/${username}/transactions/export`);
 
       if (!res.ok) {
         throw new Error("Failed to download CSV");

--- a/frontend/src/app/profile/[username]/edit/page.tsx
+++ b/frontend/src/app/profile/[username]/edit/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { getAddress } from "@stellar/freighter-api";
 import { AppShell } from "@/components/app-shell";
 import { API_BASE_URL } from "@/lib/config";
+import { apiFetch } from "@/lib/api-client";
 import { useToast } from "@/lib/use-toast";
 import { Toast } from "@/components/toast";
 
@@ -153,10 +154,6 @@ export default function EditProfilePage() {
 
     setSubmitting(true);
     try {
-      const token = typeof window !== "undefined" ? localStorage.getItem("authToken") : null;
-      const headers: Record<string, string> = { "Content-Type": "application/json" };
-      if (token) headers["Authorization"] = `Bearer ${token}`;
-
       const profilePayload: Record<string, string | null> = {
         displayName: form.displayName,
         bio: form.bio || "",
@@ -167,14 +164,14 @@ export default function EditProfilePage() {
       };
 
       const [profileRes, assetsRes] = await Promise.all([
-        fetch(`${API_BASE_URL}/profiles/${username}`, {
+        apiFetch(`${API_BASE_URL}/profiles/${username}`, {
           method: "PATCH",
-          headers,
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify(profilePayload),
         }),
-        fetch(`${API_BASE_URL}/profiles/${username}/assets`, {
+        apiFetch(`${API_BASE_URL}/profiles/${username}/assets`, {
           method: "PATCH",
-          headers,
+          headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             assets: assets.map((a) => ({
               code: a.code,

--- a/frontend/src/components/notification-preferences.tsx
+++ b/frontend/src/components/notification-preferences.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { Check } from "lucide-react";
+import { apiFetch } from "@/lib/api-client";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
 
@@ -35,12 +36,8 @@ export function NotificationPreferences({ username }: Props) {
     }
 
     Promise.all([
-      fetch(`${API_BASE_URL}/profiles/${username}/notification-preferences`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }),
-      fetch(`${API_BASE_URL}/profiles/${username}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      }),
+      apiFetch(`${API_BASE_URL}/profiles/${username}/notification-preferences`),
+      apiFetch(`${API_BASE_URL}/profiles/${username}`),
     ])
       .then(([prefsRes, profileRes]) =>
         Promise.all([
@@ -64,15 +61,11 @@ export function NotificationPreferences({ username }: Props) {
       setError(null);
 
       try {
-        const token = localStorage.getItem("authToken");
-        const res = await fetch(
+        const res = await apiFetch(
           `${API_BASE_URL}/profiles/${username}/notification-preferences`,
           {
             method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-              ...(token ? { Authorization: `Bearer ${token}` } : {}),
-            },
+            headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ [key]: newValue }),
           },
         );

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback, KeyboardEvent } from "react";
 import { isValidStellarAddress, stellarExpertUrl } from "@/lib/stellar";
 import { useToast } from "@/lib/use-toast";
 import { SITE_URL } from "@/lib/config";
+import { apiFetch } from "@/lib/api-client";
 
 import { ProfileCardSkeleton } from "./skeleton";
 
@@ -62,12 +63,8 @@ export function ProfileCard({
   const handleResend = async () => {
     setResending(true);
     try {
-      const token = localStorage.getItem("authToken");
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/profiles/${username}/resend-verification-email`, {
+      const res = await apiFetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/profiles/${username}/resend-verification-email`, {
         method: "POST",
-        headers: {
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
       });
       const data = await res.json();
       if (res.ok) {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -1,0 +1,22 @@
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("authToken") : null;
+
+  const headers = new Headers(init?.headers);
+  if (token && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const res = await fetch(input, { ...init, headers });
+
+  if (res.status === 401 && typeof window !== "undefined") {
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("username");
+    window.location.href = "/";
+  }
+
+  return res;
+}


### PR DESCRIPTION

Closes #606: currentAmount: { increment: parsed.data.amount } was passing the raw string from the request body directly to a Prisma Decimal field. Prisma coerces this implicitly, but string-to-Decimal conversion can lose precision for values exceeding 7 decimal places on some DB configurations. Adds a dedicated import of Decimal from @prisma/client/runtime/library and wraps the increment value in new Decimal(parsed.data.amount) for an explicit, safe conversion.

Closes #593: authenticated API calls across dashboard pages read the JWT from localStorage and constructed Authorization headers ad-hoc. When the token expired, each call site produced a different generic error message with no prompt to re-authenticate.

Introduces frontend/src/lib/api-client.ts — a thin apiFetch wrapper that automatically attaches the stored token to every request and centralises 401 detection: on any 401 response it clears authToken and username from localStorage then redirects to "/" so the user can reconnect their wallet.

Replaces all five call sites that previously read authToken manually:
- frontend/src/app/dashboard/page.tsx (CSV export)
- frontend/src/app/dashboard/[campaignId]/page.tsx (drip list, drip pause/cancel, resend verification email)
- frontend/src/app/profile/[username]/edit/page.tsx (profile + assets PATCH)
- frontend/src/components/notification-preferences.tsx (prefs load + toggle)
- frontend/src/components/profile-card.tsx (resend verification email)

