### PR TITLE
fix: resolve 4 security and reliability issues (#572, #573, #574, #575)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1983,7 +1983,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
     try {
       const profile = await prisma.profile.findFirst({
-        where: { username: req.params.username, emailVerificationToken: token },
+        where: { username: req.params.username as string, emailVerificationToken: token },
       });
 
       if (!profile) {
@@ -2526,7 +2526,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *         description: Internal server error
    */
   v1Router.get("/profiles/:username/transactions/export", requireAuth, async (req, res) => {
-    const { username } = req.params;
+    const username = req.params.username as string;
     const { startDate, endDate, taxYear } = req.query;
 
     try {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1974,7 +1974,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
   // ── Email verification (#275) ─────────────────────────────────────────
 
-  v1Router.post("/profiles/:username/verify-email", async (req, res) => {
+  v1Router.post("/profiles/:username/verify-email", requireAuth, async (req, res) => {
     const { token } = req.body as { token?: unknown };
 
     if (!token || typeof token !== "string") {
@@ -1985,6 +1985,15 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       const profile = await prisma.profile.findFirst({
         where: { username: req.params.username, emailVerificationToken: token },
       });
+
+      if (!profile) {
+        return sendError(res, 404, "Invalid or expired verification token", "TOKEN_INVALID");
+      }
+
+      // Ensure the authenticated user owns this profile
+      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+        return sendError(res, 403, "Forbidden: You do not own this profile");
+      }
 
       if (!profile) {
         return sendError(res, 404, "Invalid or expired verification token", "TOKEN_INVALID");
@@ -2516,7 +2525,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *       500:
    *         description: Internal server error
    */
-  v1Router.get("/profiles/:username/transactions/export", async (req, res) => {
+  v1Router.get("/profiles/:username/transactions/export", requireAuth, async (req, res) => {
     const { username } = req.params;
     const { startDate, endDate, taxYear } = req.query;
 
@@ -2527,6 +2536,11 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
       if (!profile) {
         return sendError(res, 404, "Profile not found");
+      }
+
+      // Verify the authenticated user owns this profile
+      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+        return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
       // Parse dates or use tax year
@@ -2966,6 +2980,15 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         assetCode: parsed.data.assetCode,
         assetIssuer: parsed.data.assetIssuer,
       };
+
+      // Verify the profile exists before touching Horizon (#574)
+      const profileExists = await prisma.profile.findUnique({
+        where: { id: parsed.data.profileId },
+        select: { id: true },
+      });
+      if (!profileExists) {
+        return sendError(res, 404, "Profile not found");
+      }
 
       const skipHorizonValidation = process.env.SKIP_HORIZON_VALIDATION === "true";
       if (skipHorizonValidation) {

--- a/backend/src/mailer.ts
+++ b/backend/src/mailer.ts
@@ -22,8 +22,7 @@ const transporter = nodemailer.createTransport({
 
 export async function sendEmail(options: SendEmailOptions): Promise<void> {
   if (!process.env.SMTP_HOST) {
-    logger.warn("SMTP_HOST is not set — skipping email send");
-    return;
+    return Promise.reject(new Error("SMTP_HOST is not configured — email cannot be sent"));
   }
 
   await transporter.sendMail({


### PR DESCRIPTION
## Summary
This commit resolves four distinct backend issues spanning authentication gaps, input validation, and silent error suppression.

---

### #572 — [Backend] Analytics CSV export has no auth check

**File:** backend/src/app.ts
**Route:** GET /profiles/:username/transactions/export

**Problem:** The CSV export endpoint had no authentication middleware. Any unauthenticated visitor could download the full transaction history for any profile, including supporter wallet addresses, amounts, and personal messages — a clear data-leakage vulnerability.

**Fix:** Added `requireAuth` as middleware on the route handler so only requests bearing a valid JWT are accepted. After looking up the profile, an ownership check (`req.auth.walletAddress !== profile.walletAddress`) is performed and returns 403 if the authenticated user is not the profile owner. This mirrors the ownership pattern used on every other sensitive profile endpoint in the codebase.

---

### #573 — [Backend] Email verification endpoint has no auth — token brute-force attack is possible

**File:** backend/src/app.ts
**Route:** POST /profiles/:username/verify-email

**Problem:** The email verification endpoint accepted a token in the request body with no authentication requirement. An attacker could iterate over token values to verify someone else's email address, bypassing the profile ownership model entirely.

**Fix:** Added `requireAuth` as middleware on the route handler. After the profile + token lookup succeeds, an ownership check (`req.auth.walletAddress !== profile.walletAddress`) is performed and returns 403 if the caller does not own the profile. A valid JWT matching the profile owner is now required before any verification token is accepted.

---

### #574 — [Backend] Support transaction POST uses unverified profileId before calling Horizon

**File:** backend/src/app.ts
**Route:** POST /support-transactions

**Problem:** The handler read `profileId` from the request body but did not confirm the profile existed in the database before passing the transaction hash to `verifyTransaction()` and subsequently calling `prisma.supportTransaction.create()`. A fabricated UUID could pass Horizon verification and result in a dangling SupportTransaction row pointing to a non-existent profile.

**Fix:** Added a `prisma.profile.findUnique` lookup immediately after schema validation and before the Horizon verification call. If the profile does not exist, the handler returns 404 early and never invokes verifyTransaction() or creates any database record.

---

### #575 — [Backend] Email service silently resolves when SMTP is not configured

**File:** backend/src/mailer.ts
**Function:** sendEmail()

**Problem:** When `SMTP_HOST` was not set, `sendEmail` logged a WARN and returned `undefined` (i.e., resolved the promise successfully). Every caller — verification emails, weekly digests, transaction notifications — believed the email was sent when it was silently dropped, making failures impossible to detect or surface.

**Fix:** Replaced the silent `return` with `return Promise.reject(new Error(...))` so callers that await `sendEmail` will receive a rejection. Existing callers that use `.catch()` or fire-and-forget patterns will now log the error. Callers that must guarantee delivery can handle the rejection explicitly. The `logger.warn` was removed since the rejection message itself carries the context.

---

## Files changed
- backend/src/app.ts — fixes #572, #573, #574
- backend/src/mailer.ts — fix #575

Closes #572
Closes #573
Closes #574
Closes #575

## What does this PR do?

<!-- A clear 1-3 sentence summary of the change -->

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test

<!-- Step-by-step instructions for a reviewer to verify this works -->

1.
2.
3.

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [ ] My branch is up to date with main
- [ ] Linter passes (`npm run lint`)
- [ ] Tests pass (`npm test`) if applicable
- [ ] I have not committed `.env` files or secrets
