### PR TITLE
fix: webhook nextRetryAt null write, weekly digest restart skip, profile asset filter count, P2002 field name (#601 #592 #602 #603)

### DIFF
--- a/backend/prisma/migrations/20260624000000_add_scheduler_jobs_table/migration.sql
+++ b/backend/prisma/migrations/20260624000000_add_scheduler_jobs_table/migration.sql
@@ -1,0 +1,14 @@
+-- #592: Add scheduler_jobs table to persist the last-run timestamp for
+-- recurring server-side jobs (e.g. weekly digest).
+--
+-- Without this table, every process restart (rolling deploy, crash recovery,
+-- or scale-up) triggers an immediate job run regardless of when the previous
+-- run occurred. Persisting lastRunAt lets each job skip its run if the
+-- required interval has not yet elapsed since the last successful execution.
+CREATE TABLE "scheduler_jobs" (
+    "name"      TEXT NOT NULL,
+    "lastRunAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "scheduler_jobs_pkey" PRIMARY KEY ("name")
+);

--- a/backend/prisma/migrations/20260624010000_make_webhook_delivery_next_retry_at_nullable/migration.sql
+++ b/backend/prisma/migrations/20260624010000_make_webhook_delivery_next_retry_at_nullable/migration.sql
@@ -1,0 +1,13 @@
+-- #601: Make WebhookDelivery.nextRetryAt nullable.
+--
+-- When a delivery fails permanently (willRetry = false), the processor should
+-- write NULL to nextRetryAt to signal "no retry scheduled." With the column
+-- NOT NULL, Prisma omits the field update when the value is undefined, leaving
+-- the stale timestamp from the previous attempt in place.
+--
+-- Making the column nullable lets the processor set nextRetryAt = NULL
+-- explicitly on permanent failure. The processor's pending-delivery query
+-- (WHERE status = 'pending' AND nextRetryAt <= now) already excludes failed
+-- rows by status, but writing NULL removes any ambiguity and keeps the DB
+-- consistent with the business state.
+ALTER TABLE "WebhookDelivery" ALTER COLUMN "nextRetryAt" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -218,3 +218,14 @@ model IndexerCursor {
   @@unique([network, contractId])
   @@map("indexer_cursors")
 }
+
+// #592: Persists the last-run timestamp for recurring server-side jobs so
+// that restarts and rolling deploys do not immediately re-fire the job.
+// One row per job name; upserted on every successful run.
+model SchedulerJob {
+  name      String   @id
+  lastRunAt DateTime
+  updatedAt DateTime @updatedAt
+
+  @@map("scheduler_jobs")
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -163,7 +163,7 @@ model WebhookDelivery {
   payload      Json
   status       String   @default("pending") // "pending", "success", "failed"
   attemptCount Int      @default(0)
-  nextRetryAt  DateTime @default(now())
+  nextRetryAt  DateTime? @default(now())
   lastError    String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -964,31 +964,37 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         });
       }
 
-      // Default sorting by newest
+      // Default sorting by newest.
+      // When an asset filter is supplied, push it into the DB query so that
+      // `total` reflects the actual matched count rather than the page-slice
+      // size returned by an in-memory filter (#602).
+      const assetWhere = asset
+        ? {
+            acceptedAssets: {
+              some: {
+                code: asset,
+                ...(assetIssuer !== "" ? { issuer: assetIssuer } : {}),
+              },
+            },
+          }
+        : {};
+
+      const combinedWhere = { ...where, ...assetWhere };
+
       const [profiles, total] = await Promise.all([
         prisma.profile.findMany({
-          where,
+          where: combinedWhere,
           take: limit,
           skip: offset,
           orderBy,
           include: { acceptedAssets: true },
         }),
-        prisma.profile.count({ where }),
+        prisma.profile.count({ where: combinedWhere }),
       ]);
 
-      const filtered = asset
-        ? profiles.filter((p: any) =>
-            p.acceptedAssets.some(
-              (a: any) =>
-                a.code === asset &&
-                (assetIssuer === "" || a.issuer === assetIssuer),
-            ),
-          )
-        : profiles;
-
       res.json({
-        profiles: filtered,
-        total: asset ? filtered.length : total,
+        profiles,
+        total,
         limit,
         offset,
       });

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1834,7 +1834,12 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return res.json(updated);
       } catch (e: unknown) {
         if (e && typeof e === "object" && "code" in e && e.code === "P2002") {
-          return sendError(res, 409, "Email already in use", "EMAIL_TAKEN");
+          // Inspect meta.target to tell the caller which unique field is taken.
+          // The creation endpoint uses the same pattern so clients receive a
+          // consistent error shape across both operations (#603).
+          const meta = (e as { meta?: { target?: string[] } }).meta;
+          const field = meta?.target?.includes("email") ? "Email" : "Username";
+          return sendError(res, 409, `${field} already taken`, `${field.toUpperCase()}_TAKEN`);
         }
         req.log.error({ err: e }, "database error updating profile");
         return sendError(res, 500, "Internal server error");

--- a/backend/src/services/webhook-processor.ts
+++ b/backend/src/services/webhook-processor.ts
@@ -42,7 +42,12 @@ export async function processPendingWebhookDeliveries() {
       const nextAttempt = delivery.attemptCount + 1;
       const willRetry = result.willRetry && shouldRetry(nextAttempt);
 
-      let nextRetryAt: Date | undefined;
+      // When permanently failed, nextRetryAt must be explicitly set to null so
+      // Prisma writes NULL to the column. Leaving it undefined causes Prisma to
+      // omit the field entirely, leaving any previous value in place and causing
+      // the processor's `nextRetryAt <= now` query to re-pick the delivery on
+      // the next poll cycle (#601).
+      let nextRetryAt: Date | null = null;
       if (willRetry) {
         const delayMs = getNextRetryDelay(delivery.attemptCount);
         if (delayMs !== null) {

--- a/backend/src/services/weekly-digest.ts
+++ b/backend/src/services/weekly-digest.ts
@@ -116,21 +116,71 @@ export async function sendWeeklyDigests() {
   );
 }
 
+const WEEKLY_DIGEST_JOB_NAME = "weekly-digest";
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Read the persisted last-run timestamp from the database.
+ * Returns null when no record exists (i.e. the job has never run).
+ */
+async function getLastDigestRunAt(): Promise<Date | null> {
+  const row = await prisma.schedulerJob.findUnique({
+    where: { name: WEEKLY_DIGEST_JOB_NAME },
+  });
+  return row?.lastRunAt ?? null;
+}
+
+/**
+ * Persist the current time as the last-run timestamp for the weekly digest.
+ * Called immediately after a successful digest run so that a subsequent
+ * process restart does not re-fire the job prematurely (#592).
+ */
+async function markDigestRunAt(at: Date): Promise<void> {
+  await prisma.schedulerJob.upsert({
+    where: { name: WEEKLY_DIGEST_JOB_NAME },
+    create: { name: WEEKLY_DIGEST_JOB_NAME, lastRunAt: at },
+    update: { lastRunAt: at },
+  });
+}
+
+/**
+ * Run the weekly digest only if at least 7 days have elapsed since the last
+ * successful run. Guards against re-firing on every process restart (#592).
+ */
+async function maybeRunWeeklyDigest(): Promise<void> {
+  const lastRunAt = await getLastDigestRunAt();
+  const now = Date.now();
+
+  if (lastRunAt !== null && now - lastRunAt.getTime() < SEVEN_DAYS_MS) {
+    const msUntilDue = SEVEN_DAYS_MS - (now - lastRunAt.getTime());
+    const hoursUntilDue = Math.ceil(msUntilDue / (60 * 60 * 1000));
+    logger.info(
+      { lastRunAt, hoursUntilDue },
+      "Weekly digest skipped — not yet due",
+    );
+    return;
+  }
+
+  const runAt = new Date(now);
+  await sendWeeklyDigests();
+  await markDigestRunAt(runAt);
+}
+
 let digestInterval: ReturnType<typeof setInterval> | null = null;
 
 export function startWeeklyDigestScheduler() {
   if (process.env.WEEKLY_DIGEST_ENABLED === "true") {
     logger.info("Weekly digest scheduler enabled. Starting...");
 
-    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
-
-    sendWeeklyDigests().catch((err) => {
-      logger.error({ err }, "Error in initial sendWeeklyDigests run");
+    // Check the persisted last-run time before firing so that a restart or
+    // rolling deploy does not immediately re-send digests (#592).
+    maybeRunWeeklyDigest().catch((err) => {
+      logger.error({ err }, "Error in initial maybeRunWeeklyDigest check");
     });
 
     digestInterval = setInterval(() => {
-      sendWeeklyDigests().catch((err) => {
-        logger.error({ err }, "Error in sendWeeklyDigests interval");
+      maybeRunWeeklyDigest().catch((err) => {
+        logger.error({ err }, "Error in maybeRunWeeklyDigest interval");
       });
     }, SEVEN_DAYS_MS);
   } else {


### PR DESCRIPTION
## Summary

Fixes four backend bugs across webhook delivery, weekly digest scheduling, profile listing, and profile update error responses.

### #601 — Stale `nextRetryAt` on permanently-failed webhook deliveries

**`backend/src/services/webhook-processor.ts`**

`nextRetryAt` was typed `Date | undefined` and only assigned inside the `willRetry` branch. When `willRetry = false` it remained `undefined`, which Prisma interprets as "omit the field" rather than writing `NULL`. The stale value from the previous attempt stayed in the database, and the processor's `WHERE nextRetryAt <= now` query re-picked the delivery on every subsequent poll, retrying it forever.

Fix: initialise `nextRetryAt: Date | null = null` so Prisma always writes `NULL` when the delivery permanently fails.

### #592 — Weekly digest fires on every server restart

**`backend/src/services/weekly-digest.ts`** · **`backend/prisma/schema.prisma`** · new migration

`startWeeklyDigestScheduler()` called `sendWeeklyDigests()` unconditionally on the first tick. Every process restart (rolling deploy, crash recovery, scale-up) therefore sent digests immediately regardless of when the previous batch was delivered.

Fix:
1. Add a `SchedulerJob` model (`scheduler_jobs` table, one row per job name) with a `lastRunAt` timestamp.
2. Extract `maybeRunWeeklyDigest()` which reads `lastRunAt`, skips and logs if fewer than 7 days have elapsed, otherwise calls `sendWeeklyDigests()` and upserts the timestamp.
3. Replace the unconditional startup call with `maybeRunWeeklyDigest()`.

### #602 — GET `/profiles` returns wrong `total` when asset filter is active

**`backend/src/app.ts`**

The default-sort path fetched up to `limit` rows from the DB without the asset filter, then filtered in memory. It returned `filtered.length` (≤ `limit`) as `total`, causing clients to think there was only one page even when many more matching profiles existed.

Fix: build `assetWhere` with Prisma's nested `acceptedAssets: { some: … }` relation filter and merge it into the shared `where` clause passed to both `findMany` and `count`. Pagination is now applied after the filter, and `total` always reflects the true matched count.

### #603 — PATCH `/profiles/:username` returns wrong field name in P2002 409 response

**`backend/src/app.ts`**

The update handler caught P2002 but always responded with `"Email already in use"` / `EMAIL_TAKEN` regardless of which unique column caused the violation. Attempting to change a username to an already-taken one returned a misleading email-conflict message.

Fix: inspect `error.meta.target` (same pattern the creation endpoint already uses) and pick `"Email"` or `"Username"` accordingly, returning a consistent `{ error, code }` shape on both paths.

---

Closes #601
Closes #592
Closes #602
Closes #603