### PR TITLE
Fix backend issues 591, 590, 589, 588

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,10 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.5.0",
-        "@sentry/node": "^8.0.0",
+        "@sentry/node": "^8.55.2",
         "@stellar/stellar-sdk": "^14.6.1",
         "@supabase/supabase-js": "^2.100.1",
-        "@types/sanitize-html": "^2.16.1",
         "compression": "^1.8.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
@@ -23,7 +22,7 @@
         "nodemailer": "^6.9.16",
         "pino": "^9.6.0",
         "pino-http": "^10.4.0",
-        "sanitize-html": "^2.17.3",
+        "sanitize-html": "^2.17.5",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "zod": "^3.24.2"
@@ -36,6 +35,7 @@
         "@types/multer": "^1.4.13",
         "@types/node": "^22.13.14",
         "@types/nodemailer": "^6.4.17",
+        "@types/sanitize-html": "^2.16.1",
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
@@ -743,7 +743,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -765,7 +764,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -802,7 +800,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -1342,7 +1339,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
       "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1905,6 +1901,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
       "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "htmlparser2": "^10.1"
@@ -2008,7 +2005,6 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2325,7 +2321,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2866,6 +2861,12 @@
         "node": "*"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3243,7 +3244,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3473,7 +3473,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4235,7 +4234,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4340,6 +4338,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
       }
     },
     "node_modules/levn": {
@@ -4872,7 +4879,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5069,7 +5075,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -5358,15 +5363,16 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }
@@ -5887,7 +5893,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,10 +23,9 @@
   },
   "dependencies": {
     "@prisma/client": "^6.5.0",
-    "@sentry/node": "^8.0.0",
+    "@sentry/node": "^8.55.2",
     "@stellar/stellar-sdk": "^14.6.1",
     "@supabase/supabase-js": "^2.100.1",
-    "@types/sanitize-html": "^2.16.1",
     "compression": "^1.8.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
@@ -37,7 +36,7 @@
     "nodemailer": "^6.9.16",
     "pino": "^9.6.0",
     "pino-http": "^10.4.0",
-    "sanitize-html": "^2.17.3",
+    "sanitize-html": "^2.17.5",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "zod": "^3.24.2"
@@ -50,6 +49,7 @@
     "@types/multer": "^1.4.13",
     "@types/node": "^22.13.14",
     "@types/nodemailer": "^6.4.17",
+    "@types/sanitize-html": "^2.16.1",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^8.57.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4394,7 +4394,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   // Must be registered after all routes and before any other error handlers
   if (process.env.SENTRY_DSN) {
     app.use(Sentry.expressErrorHandler({
-      shouldHandleError(error) {
+      shouldHandleError(_error: Error) {
         // Capture 4xx client errors as well as 5xx server errors
         return true;
       },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3594,6 +3594,46 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     }
   });
 
+  // ── Webhooks Admin ─────────────────────────────────────────────────────
+
+  /**
+   * @openapi
+   * /admin/webhooks/requeue:
+   *   post:
+   *     summary: Requeue permanently failed webhook deliveries (admin only)
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Number of webhooks requeued
+   *       403:
+   *         description: Admin access required
+   *       500:
+   *         description: Internal server error
+   */
+  v1Router.post("/admin/webhooks/requeue", requireAuth, async (req, res) => {
+    if (!req.auth || !ADMIN_WALLET || req.auth.walletAddress !== ADMIN_WALLET) {
+      return sendError(res, 403, "Forbidden: Admin access required");
+    }
+
+    try {
+      const result = await prisma.webhookDelivery.updateMany({
+        where: { status: "failed" },
+        data: {
+          status: "pending",
+          attemptCount: 0,
+          nextRetryAt: new Date(),
+        },
+      });
+
+      req.log.info({ count: result.count }, "requeued failed webhooks");
+      return res.json({ count: result.count });
+    } catch (e: unknown) {
+      req.log.error({ err: e }, "database error requeuing webhooks");
+      return sendError(res, 500, "Internal server error");
+    }
+  });
+
   // ── Profile Badges ─────────────────────────────────────────────────────
 
   v1Router.get("/profiles/:username/badges", async (req, res) => {

--- a/backend/src/services/badge-awarder.ts
+++ b/backend/src/services/badge-awarder.ts
@@ -11,74 +11,85 @@ function getBadgeNameByCriterion(criterion: string): string {
   return map[criterion] ?? "";
 }
 
+const pendingChecks = new Set<string>();
+
 export async function checkAndAwardBadges(profileId: string): Promise<void> {
-  try {
-    const badges = await prisma.badge.findMany();
-    if (badges.length === 0) return;
+  if (pendingChecks.has(profileId)) return;
+  pendingChecks.add(profileId);
 
-    const existingAwards = await prisma.profileBadge.findMany({
-      where: { profileId },
-      select: { badgeId: true },
-    });
-    const awardedBadgeIds = new Set(existingAwards.map((a) => a.badgeId));
+  setTimeout(async () => {
+    try {
+      const badges = await prisma.badge.findMany();
+      if (badges.length === 0) return;
 
-    const [txCount, uniqueSupporters, totalsByAsset, milestonesReached] = await Promise.all([
-      prisma.supportTransaction.count({
-        where: { profileId, status: { not: "failed" } },
-      }),
-      prisma.supportTransaction.findMany({
-        where: { profileId, supporterAddress: { not: null }, status: { not: "failed" } },
-        distinct: ["supporterAddress"],
-        select: { supporterAddress: true },
-      }),
-      prisma.supportTransaction.groupBy({
-        by: ["assetCode"],
-        where: { profileId, status: { not: "failed" } },
-        _sum: { amount: true },
-      }),
-      prisma.milestone.count({
-        where: { profileId, status: "reached" },
-      }),
-    ]);
+      const existingAwards = await prisma.profileBadge.findMany({
+        where: { profileId },
+        select: { badgeId: true },
+      });
+      const awardedBadgeIds = new Set(existingAwards.map((a) => a.badgeId));
 
-    const xlmTotal = totalsByAsset
-      .filter((g) => g.assetCode === "XLM")
-      .reduce((sum, g) => sum + Number(g._sum.amount ?? 0), 0);
+      if (awardedBadgeIds.size === badges.length) return;
 
-    for (const badge of badges) {
-      if (awardedBadgeIds.has(badge.id)) continue;
+      const [txCount, uniqueSupporters, totalsByAsset, milestonesReached] = await Promise.all([
+        prisma.supportTransaction.count({
+          where: { profileId, status: { not: "failed" } },
+        }),
+        prisma.supportTransaction.findMany({
+          where: { profileId, supporterAddress: { not: null }, status: { not: "failed" } },
+          distinct: ["supporterAddress"],
+          select: { supporterAddress: true },
+        }),
+        prisma.supportTransaction.groupBy({
+          by: ["assetCode"],
+          where: { profileId, status: { not: "failed" } },
+          _sum: { amount: true },
+        }),
+        prisma.milestone.count({
+          where: { profileId, status: "reached" },
+        }),
+      ]);
 
-      let shouldAward = false;
+      const xlmTotal = totalsByAsset
+        .filter((g) => g.assetCode === "XLM")
+        .reduce((sum, g) => sum + Number(g._sum.amount ?? 0), 0);
 
-      switch (badge.criteria) {
-        case "first_support":
-          shouldAward = txCount >= 1;
-          break;
-        case "ten_supporters":
-          shouldAward = uniqueSupporters.length >= 10;
-          break;
-        case "total_100_xlm":
-          shouldAward = xlmTotal >= 100;
-          break;
-        case "milestone_reached":
-          shouldAward = milestonesReached >= 1;
-          break;
+      for (const badge of badges) {
+        if (awardedBadgeIds.has(badge.id)) continue;
+
+        let shouldAward = false;
+
+        switch (badge.criteria) {
+          case "first_support":
+            shouldAward = txCount >= 1;
+            break;
+          case "ten_supporters":
+            shouldAward = uniqueSupporters.length >= 10;
+            break;
+          case "total_100_xlm":
+            shouldAward = xlmTotal >= 100;
+            break;
+          case "milestone_reached":
+            shouldAward = milestonesReached >= 1;
+            break;
+        }
+
+        if (shouldAward) {
+          await prisma.profileBadge.create({
+            data: { profileId, badgeId: badge.id },
+          });
+          logger.info(
+            { profileId, badgeName: badge.name },
+            "Badge auto-awarded",
+          );
+        }
       }
-
-      if (shouldAward) {
-        await prisma.profileBadge.create({
-          data: { profileId, badgeId: badge.id },
-        });
-        logger.info(
-          { profileId, badgeName: badge.name },
-          "Badge auto-awarded",
-        );
-      }
+    } catch (err) {
+      logger.error(
+        { err, profileId },
+        "Error in checkAndAwardBadges",
+      );
+    } finally {
+      pendingChecks.delete(profileId);
     }
-  } catch (err) {
-    logger.error(
-      { err, profileId },
-      "Error in checkAndAwardBadges",
-    );
-  }
+  }, 5000);
 }

--- a/backend/src/services/event-indexer.ts
+++ b/backend/src/services/event-indexer.ts
@@ -326,13 +326,14 @@ export class EventIndexer {
           { ingested, contractId: this.contractId },
           "indexed events",
         );
-        await this.resolveOrphans().catch((err) => {
-          Metrics.eventIndexerErrors();
-          logger.warn({ err }, "orphan resolution failed — will retry next tick");
-        });
         // More pages available — re-enter immediately but yield to the event loop.
         if (nextCursor !== null) delay = 0;
       }
+
+      await this.resolveOrphans().catch((err) => {
+        Metrics.eventIndexerErrors();
+        logger.error({ err }, "orphan resolution failed — operator intervention required");
+      });
     } catch (err) {
       Metrics.eventIndexerErrors();
       logger.error({ err }, "event indexer tick failed");

--- a/backend/src/services/soroban-rpc-client.ts
+++ b/backend/src/services/soroban-rpc-client.ts
@@ -99,13 +99,13 @@ function decodeSupportEvent(event: RpcEvent): SupportEventRecord | null {
     txHash: event.txHash,
     ledger: event.ledger,
     pagingToken: event.pagingToken ?? event.id,
-    amount: String(native.amount ?? "0"),
-    assetCode: String(native.asset_code ?? native.assetCode ?? ""),
+    amount: String(nativeObj.amount ?? "0"),
+    assetCode: String(nativeObj.asset_code ?? nativeObj.assetCode ?? ""),
     assetIssuer: null,
     recipientAddress: asAddress(recipient),
     supporterAddress: asAddress(supporter),
-    message: native.message == null ? null : String(native.message),
-    emittedAt: new Date(toNumber(native.timestamp) * 1000),
+    message: nativeObj.message == null ? null : String(nativeObj.message),
+    emittedAt: new Date(toNumber(nativeObj.timestamp) * 1000),
   };
 }
 

--- a/backend/src/services/soroban-rpc-client.ts
+++ b/backend/src/services/soroban-rpc-client.ts
@@ -5,6 +5,7 @@ import type {
   RpcEventPage,
   SupportEventRecord,
 } from "./event-indexer.js";
+import { logger } from "../logger.js";
 
 type RpcEvent = {
   ledger: number;
@@ -54,16 +55,45 @@ function toNumber(value: unknown): number {
 function decodeSupportEvent(event: RpcEvent): SupportEventRecord | null {
   if (!event.topic.length) return null;
 
-  const native = scValToNative(xdr.ScVal.fromXDR(event.value, "base64")) as
-    | Record<string, unknown>
-    | unknown[];
+  let native: unknown;
+  try {
+    native = scValToNative(xdr.ScVal.fromXDR(event.value, "base64"));
+  } catch (err) {
+    logger.warn({
+      msg: "Malformed support event payload discarded (XDR decode error)",
+      ledger: event.ledger,
+      contractId: event.contractId,
+      txHash: event.txHash,
+      err
+    });
+    return null;
+  }
 
-  if (!native || Array.isArray(native)) return null;
+  if (!native || Array.isArray(native) || typeof native !== "object") {
+    logger.warn({
+      msg: "Malformed support event payload discarded (not an object)",
+      ledger: event.ledger,
+      contractId: event.contractId,
+      txHash: event.txHash,
+      native
+    });
+    return null;
+  }
 
-  const supporter = native.supporter;
-  const recipient = native.recipient;
+  const nativeObj = native as Record<string, unknown>;
+  const supporter = nativeObj.supporter;
+  const recipient = nativeObj.recipient;
 
-  if (!supporter || !recipient) return null;
+  if (!supporter || !recipient) {
+    logger.warn({
+      msg: "Malformed support event payload discarded (missing supporter or recipient)",
+      ledger: event.ledger,
+      contractId: event.contractId,
+      txHash: event.txHash,
+      native: nativeObj
+    });
+    return null;
+  }
 
   return {
     txHash: event.txHash,


### PR DESCRIPTION
## What does this PR do?

This PR resolves four open issues in the NovaSupport backend repository:

- **#591** — Backend: Updates `SorobanRpcClient.decodeSupportEvent` to log malformed contract event payloads at `WARN` level before discarding them, preventing silent data loss.
- **#590** — Backend: Modifies `EventIndexer` to retry orphaned transaction resolution on every tick and escalates permanent resolution errors to `ERROR` level for operator intervention.
- **#589** — Backend: Wraps the `checkAndAwardBadges` logic in an asynchronous memory debouncer per `profileId` to prevent 4 synchronous database queries from firing on every single support transaction write path.
- **#588** — Backend: Adds a new Dead Letter Queue (DLQ) concept for failed webhooks by implementing an admin-only endpoint (`POST /admin/webhooks/requeue`) to reset and retry all permanently failed deliveries.

## Related issue

Closes #591, Closes #590, Closes #589, Closes #588

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test

1. **#591**: Emit a malformed support event from a mock contract and verify the `logger.warn` output correctly details the unparseable payload rather than failing silently.
2. **#590**: Seed a profile ID as `__orphan__` while simulating an indexer tick. Verify the resolver fires and properly alerts on failure via `logger.error` if the corresponding profile does not exist.
3. **#589**: Trigger multiple rapid support transactions for the same profile; check logs to verify `checkAndAwardBadges` fires only once after a 5-second debounce.
4. **#588**: As an admin, call `POST /admin/webhooks/requeue`. Verify any previously `failed` webhooks are reset to `pending` with `attemptCount = 0` and are retried.

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My branch is up to date with main
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm test`) if applicable
- [x] I have not committed `.env` files or secrets
