### PR TITLE
[codex] Fix backend shutdown, pagination, ownership, and breaker persistence

### DIFF
--- a/backend/prisma/migrations/20260624020000_add_circuit_breaker_states/migration.sql
+++ b/backend/prisma/migrations/20260624020000_add_circuit_breaker_states/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "circuit_breaker_states" (
+    "name" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "failureCount" INTEGER NOT NULL DEFAULT 0,
+    "nextAttemptAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "circuit_breaker_states_pkey" PRIMARY KEY ("name")
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -229,3 +229,17 @@ model SchedulerJob {
 
   @@map("scheduler_jobs")
 }
+
+// #583: Durable state for external-service circuit breakers. This prevents a
+// process restart during an upstream outage from resetting an OPEN breaker to
+// CLOSED and immediately sending a fresh burst of requests.
+model CircuitBreakerState {
+  name          String    @id
+  state         String
+  failureCount  Int       @default(0)
+  nextAttemptAt DateTime?
+  updatedAt     DateTime  @updatedAt
+  createdAt     DateTime  @default(now())
+
+  @@map("circuit_breaker_states")
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -36,7 +36,7 @@ import {
 } from "./services/profile-leaderboard-cache.js";
 import { processPendingWebhookDeliveries } from "./services/webhook-processor.js";
 import { sanitizeBody, sanitizeQuery } from "./middleware/sanitize.js";
-import { CircuitBreaker } from "./services/circuit-breaker.js";
+import { CircuitBreaker, type CircuitBreakerStorage, type State } from "./services/circuit-breaker.js";
 import {
   validateUsername,
   validateUsernameWithTakenCheck,
@@ -65,7 +65,45 @@ const MAX_FILE_SIZE = 2_097_152;
 const horizonUrl =
   process.env.HORIZON_URL ?? "https://horizon-testnet.stellar.org";
 const stellarServer = new Horizon.Server(horizonUrl);
-const horizonCircuitBreaker = new CircuitBreaker(5, 30000); // 5 failures, 30s reset
+function createPrismaCircuitBreakerStorage(name: string): CircuitBreakerStorage {
+  return {
+    async load() {
+      const row = await prisma.circuitBreakerState.findUnique({
+        where: { name },
+      });
+      if (!row) return null;
+      const state = ["CLOSED", "OPEN", "HALF_OPEN"].includes(row.state)
+        ? (row.state as State)
+        : "CLOSED";
+      return {
+        state,
+        failureCount: row.failureCount,
+        nextAttempt: row.nextAttemptAt ? row.nextAttemptAt.getTime() : 0,
+      };
+    },
+    async save(snapshot) {
+      await prisma.circuitBreakerState.upsert({
+        where: { name },
+        create: {
+          name,
+          state: snapshot.state,
+          failureCount: snapshot.failureCount,
+          nextAttemptAt: snapshot.nextAttempt ? new Date(snapshot.nextAttempt) : null,
+        },
+        update: {
+          state: snapshot.state,
+          failureCount: snapshot.failureCount,
+          nextAttemptAt: snapshot.nextAttempt ? new Date(snapshot.nextAttempt) : null,
+        },
+      });
+    },
+  };
+}
+const horizonCircuitBreaker = new CircuitBreaker(
+  5,
+  30000,
+  createPrismaCircuitBreakerStorage("horizon"),
+); // 5 failures, 30s reset
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -254,6 +292,20 @@ const paginationSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
   offset: z.coerce.number().int().min(0).default(0),
 });
+
+const profileSearchPaginationSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+type OwnedProfile = {
+  ownerId: string;
+  walletAddress: string;
+};
+
+function isProfileOwner(auth: AuthContext | undefined, profile: OwnedProfile): boolean {
+  if (!auth) return false;
+  return auth.walletAddress === profile.walletAddress || auth.userId === profile.ownerId;
+}
 
 function sendError(
   res: Response,
@@ -1114,7 +1166,11 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       // Ensure pg_trgm extension is available
       await prisma.$executeRawUnsafe("CREATE EXTENSION IF NOT EXISTS pg_trgm");
 
-      const limit = Math.min(parseInt(req.query.limit as string) || 10, 50);
+      const pagination = profileSearchPaginationSchema.safeParse(req.query);
+      if (!pagination.success) {
+        return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+      }
+      const { limit } = pagination.data;
 
       // Fuzzy search with relevance scoring using pg_trgm similarity
       const profiles = await prisma.$queryRawUnsafe<
@@ -1286,7 +1342,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       // Attempt to increment view count; viewCountLimiter will skip duplicate
       // IPs within the same hour window (applied as middleware below).
       // Skip increment if the viewer is the profile owner (#542).
-      const isOwner = req.auth?.userId && profile.ownerId === req.auth.userId;
+      const isOwner = isProfileOwner(req.auth, profile);
       if (!isOwner) {
         void prisma.profile.update({
           where: { id: profile.id },
@@ -1299,7 +1355,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       const responseBody: Record<string, unknown> = { ...profile };
       if (req.auth) {
         responseBody.isOwner = Boolean(
-          req.auth.userId && profile.ownerId === req.auth.userId,
+          isProfileOwner(req.auth, profile),
         );
       }
 
@@ -1795,7 +1851,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Verify authenticated wallet owns the profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -1935,7 +1991,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return sendError(res, 404, "Profile not found");
       }
 
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -2002,7 +2058,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Ensure the authenticated user owns this profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -2036,8 +2092,6 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     resendLimiter,
     async (req, res) => {
       const username = req.params.username as string;
-      const userId = (req.auth!.userId || req.auth!.walletAddress) as string;
-
       try {
         const profile = await prisma.profile.findUnique({
           where: { username },
@@ -2048,7 +2102,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
           return sendError(res, 404, "Profile not found");
         }
 
-        if (profile.ownerId !== userId) {
+        if (!isProfileOwner(req.auth, profile)) {
           return sendError(res, 403, "Forbidden");
         }
 
@@ -2095,7 +2149,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     const profile = await prisma.profile.findUnique({ where: { username } });
     if (!profile) return sendError(res, 404, "Profile not found");
 
-    if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+    if (!isProfileOwner(req.auth, profile)) {
       return sendError(res, 403, "Forbidden: You do not own this profile");
     }
 
@@ -2124,7 +2178,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     const profile = await prisma.profile.findUnique({ where: { username } });
     if (!profile) return sendError(res, 404, "Profile not found");
 
-    if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+    if (!isProfileOwner(req.auth, profile)) {
       return sendError(res, 403, "Forbidden: You do not own this profile");
     }
 
@@ -2227,7 +2281,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return sendError(res, 404, "Profile not found");
       }
 
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -2550,7 +2604,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Verify the authenticated user owns this profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -2655,7 +2709,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   // Helper: resolve profile and verify owner
   async function resolveProfileOwner(
     username: string,
-    ownerId: string,
+    auth: AuthContext | undefined,
     res: Response,
   ) {
     const profile = await prisma.profile.findUnique({ where: { username } });
@@ -2663,7 +2717,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       sendError(res, 404, "Profile not found");
       return null;
     }
-    if (profile.ownerId !== ownerId) {
+    if (!isProfileOwner(auth, profile)) {
       sendError(res, 403, "Forbidden");
       return null;
     }
@@ -2674,7 +2728,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     const parsed = webhookCreateSchema.safeParse(req.body);
     if (!parsed.success) return sendError(res, 400, "Invalid URL — must be a valid HTTPS URL");
 
-    const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
+    const profile = await resolveProfileOwner(req.params.username as string, req.auth, res);
     if (!profile) return;
 
     const secret = randomBytes(32).toString("hex");
@@ -2686,7 +2740,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   });
 
   v1Router.get("/profiles/:username/webhooks", requireAuth, async (req, res) => {
-    const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
+    const profile = await resolveProfileOwner(req.params.username as string, req.auth, res);
     if (!profile) return;
 
     const webhooks = await prisma.webhook.findMany({
@@ -2698,7 +2752,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   });
 
   v1Router.delete("/profiles/:username/webhooks/:id", requireAuth, async (req, res) => {
-    const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
+    const profile = await resolveProfileOwner(req.params.username as string, req.auth, res);
     if (!profile) return;
 
     const webhook = await prisma.webhook.findFirst({
@@ -2711,7 +2765,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   });
 
   v1Router.get("/profiles/:username/webhooks/:id/deliveries", requireAuth, async (req, res) => {
-    const profile = await resolveProfileOwner(req.params.username as string, (req.auth!.userId || req.auth!.walletAddress) as string, res);
+    const profile = await resolveProfileOwner(req.params.username as string, req.auth, res);
     if (!profile) return;
 
     const webhook = await prisma.webhook.findFirst({
@@ -2719,8 +2773,11 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     });
     if (!webhook) return sendError(res, 404, "Webhook not found");
 
-    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100);
-    const offset = parseInt(req.query.offset as string) || 0;
+    const pagination = paginationSchema.safeParse(req.query);
+    if (!pagination.success) {
+      return sendError(res, 400, "Invalid pagination parameters", "INVALID_PAGINATION");
+    }
+    const { limit, offset } = pagination.data;
 
     const [deliveries, total] = await Promise.all([
       prisma.webhookDelivery.findMany({
@@ -3453,7 +3510,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Verify authenticated wallet owns the profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -3698,7 +3755,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Verify authenticated wallet owns the profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -3758,7 +3815,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Verify authenticated wallet owns the profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -3800,7 +3857,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       }
 
       // Verify authenticated wallet owns the profile
-      if (!req.auth || req.auth.walletAddress !== profile.walletAddress) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "Forbidden: You do not own this profile");
       }
 
@@ -3955,7 +4012,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       // Creator view — return drips for this profile if caller owns it
       const profile = await prisma.profile.findUnique({ where: { id: profileId } });
       if (!profile) return sendError(res, 404, "Profile not found");
-      if (profile.walletAddress !== req.auth!.walletAddress) return sendError(res, 403, "Forbidden");
+      if (!isProfileOwner(req.auth, profile)) return sendError(res, 403, "Forbidden");
 
       const subscriptions = await prisma.recurringSupport.findMany({
         where: { profileId, status: { not: "cancelled" } },
@@ -4132,7 +4189,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return sendError(res, 404, "Profile not found");
       }
 
-      if (profile.ownerId !== user.id) {
+      if (!isProfileOwner(req.auth, profile)) {
         return sendError(res, 403, "You can only delete your own profile");
       }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -102,7 +102,7 @@ import { startDripScheduler } from "./services/drip-scheduler.js";
 import { startWebhookProcessor } from "./services/webhook-processor.js";
 import { EventIndexer } from "./services/event-indexer.js";
 import { createSorobanRpcClient } from "./services/soroban-rpc-client.js";
-import { startWeeklyDigestScheduler } from "./services/weekly-digest.js";
+import { startWeeklyDigestScheduler, stopWeeklyDigestScheduler } from "./services/weekly-digest.js";
 import { prisma } from "./db.js";
 
 const port = Number(process.env.PORT ?? 4000);
@@ -133,17 +133,21 @@ const eventIndexer =
       })
     : null;
 
-app.listen(port, () => {
+let dripScheduler: ReturnType<typeof startDripScheduler> | null = null;
+let webhookProcessor: ReturnType<typeof startWebhookProcessor> | null = null;
+let shuttingDown = false;
+
+const server = app.listen(port, () => {
   logger.info({ port }, `NovaSupport backend listening on http://localhost:${port}`);
 
   // Start the recurring drip scheduler if enabled
-  startDripScheduler();
+  dripScheduler = startDripScheduler();
 
   // Start the weekly digest email scheduler
   startWeeklyDigestScheduler();
 
   // Start the webhook delivery processor
-  startWebhookProcessor();
+  webhookProcessor = startWebhookProcessor();
 
   if (eventIndexer) {
     eventIndexer.start();
@@ -156,4 +160,43 @@ app.listen(port, () => {
       "Soroban event indexer disabled - set SOROBAN_CONTRACT_ID to enable it",
     );
   }
+});
+
+async function shutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  logger.info({ signal }, "Shutdown signal received");
+
+  try {
+    await Promise.all([
+      dripScheduler?.stop(),
+      webhookProcessor?.stop(),
+      eventIndexer?.stop(),
+      Promise.resolve().then(() => stopWeeklyDigestScheduler()),
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    await prisma.$disconnect();
+    await Sentry.close(2_000);
+    logger.info({ signal }, "Graceful shutdown complete");
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  } catch (err) {
+    logger.error({ err, signal }, "Graceful shutdown failed");
+    process.exit(1);
+  }
+}
+
+process.once("SIGTERM", () => {
+  void shutdown("SIGTERM");
+});
+
+process.once("SIGINT", () => {
+  void shutdown("SIGINT");
 });

--- a/backend/src/services/circuit-breaker.test.ts
+++ b/backend/src/services/circuit-breaker.test.ts
@@ -1,6 +1,26 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { CircuitBreaker } from "./circuit-breaker.js";
+import { CircuitBreaker, type CircuitBreakerSnapshot, type CircuitBreakerStorage } from "./circuit-breaker.js";
+
+function memoryStorage(initial: CircuitBreakerSnapshot | null = null): {
+  storage: CircuitBreakerStorage;
+  snapshots: CircuitBreakerSnapshot[];
+} {
+  let current = initial;
+  const snapshots: CircuitBreakerSnapshot[] = [];
+  return {
+    snapshots,
+    storage: {
+      async load() {
+        return current;
+      },
+      async save(snapshot) {
+        current = { ...snapshot };
+        snapshots.push({ ...snapshot });
+      },
+    },
+  };
+}
 
 test("CircuitBreaker starts in CLOSED state", () => {
   const cb = new CircuitBreaker();
@@ -175,7 +195,6 @@ test("CircuitBreaker respects custom failure threshold and timeout", async () =>
   }
 
   assert.equal(cb.getState(), "OPEN");
-  (cb as unknown as { failureThreshold: number }).failureThreshold;
   assert.equal(
     (cb as unknown as { failureThreshold: number }).failureThreshold,
     THRESHOLD,
@@ -216,4 +235,41 @@ test("CircuitBreaker re-throws the original error from the function", async () =
       return true;
     },
   );
+});
+
+test("CircuitBreaker persists OPEN state after threshold failures", async () => {
+  const { storage, snapshots } = memoryStorage();
+  const cb = new CircuitBreaker(1, 99999, storage);
+
+  await assert.rejects(
+    cb.execute(async () => {
+      throw new Error("upstream down");
+    }),
+  );
+
+  assert.equal(cb.getState(), "OPEN");
+  assert.equal(snapshots.at(-1)?.state, "OPEN");
+  assert.equal(snapshots.at(-1)?.failureCount, 1);
+  assert.ok((snapshots.at(-1)?.nextAttempt ?? 0) > Date.now());
+});
+
+test("CircuitBreaker restores persisted OPEN state and blocks calls before reset", async () => {
+  const { storage } = memoryStorage({
+    state: "OPEN",
+    failureCount: 5,
+    nextAttempt: Date.now() + 99999,
+  });
+  const cb = new CircuitBreaker(5, 30000, storage);
+  let executed = false;
+
+  await assert.rejects(
+    cb.execute(async () => {
+      executed = true;
+      return "should not run";
+    }),
+    /Circuit breaker is OPEN/,
+  );
+
+  assert.equal(executed, false);
+  assert.equal(cb.getState(), "OPEN");
 });

--- a/backend/src/services/circuit-breaker.ts
+++ b/backend/src/services/circuit-breaker.ts
@@ -1,7 +1,18 @@
 import { logger } from "../logger.js";
 import { Metrics } from "../metrics.js";
 
-type State = "CLOSED" | "OPEN" | "HALF_OPEN";
+export type State = "CLOSED" | "OPEN" | "HALF_OPEN";
+
+export type CircuitBreakerSnapshot = {
+  state: State;
+  failureCount: number;
+  nextAttempt: number;
+};
+
+export type CircuitBreakerStorage = {
+  load(): Promise<CircuitBreakerSnapshot | null>;
+  save(snapshot: CircuitBreakerSnapshot): Promise<void>;
+};
 
 export class CircuitBreaker {
   private state: State = "CLOSED";
@@ -9,17 +20,26 @@ export class CircuitBreaker {
   private resetTimeout: number;
   private failureCount: number = 0;
   private nextAttempt: number = 0;
+  private readonly storage: CircuitBreakerStorage | null;
+  private initialized: Promise<void> | null = null;
 
-  constructor(failureThreshold = 5, resetTimeout = 30000) {
+  constructor(
+    failureThreshold = 5,
+    resetTimeout = 30000,
+    storage: CircuitBreakerStorage | null = null,
+  ) {
     this.failureThreshold = failureThreshold;
     this.resetTimeout = resetTimeout;
+    this.storage = storage;
     Metrics.circuitBreakerState("CLOSED");
   }
 
   async execute<T>(fn: () => Promise<T>): Promise<T> {
+    await this.ensureInitialized();
+
     if (this.state === "OPEN") {
       if (Date.now() >= this.nextAttempt) {
-        this.state = "HALF_OPEN";
+        await this.setState("HALF_OPEN");
         Metrics.circuitBreakerState("HALF_OPEN");
         logger.info("Circuit breaker state: HALF_OPEN");
       } else {
@@ -29,37 +49,91 @@ export class CircuitBreaker {
 
     try {
       const result = await fn();
-      this.onSuccess();
+      await this.onSuccess();
       return result;
     } catch (error) {
-      this.onFailure();
+      await this.onFailure();
       throw error;
     }
   }
 
-  private onSuccess() {
+  private async onSuccess() {
     this.failureCount = 0;
     if (this.state === "HALF_OPEN") {
-      this.state = "CLOSED";
+      await this.setState("CLOSED");
       Metrics.circuitBreakerState("CLOSED");
       logger.info("Circuit breaker state: CLOSED");
+    } else {
+      await this.persist();
     }
   }
 
-  private onFailure() {
+  private async onFailure() {
     this.failureCount++;
     if (this.state === "HALF_OPEN" || this.failureCount >= this.failureThreshold) {
-      this.state = "OPEN";
       this.nextAttempt = Date.now() + this.resetTimeout;
+      await this.setState("OPEN");
       Metrics.circuitBreakerState("OPEN");
       logger.warn(
         { failureCount: this.failureCount, nextAttempt: new Date(this.nextAttempt).toISOString() },
         "Circuit breaker state: OPEN"
       );
+    } else {
+      await this.persist();
     }
   }
 
   getState(): State {
     return this.state;
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (!this.storage) return;
+    this.initialized ??= this.storage.load()
+      .then(async (snapshot) => {
+        if (!snapshot) {
+          await this.persist();
+          return;
+        }
+        this.state = snapshot.state;
+        this.failureCount = snapshot.failureCount;
+        this.nextAttempt = snapshot.nextAttempt;
+
+        if (this.state === "OPEN" && Date.now() >= this.nextAttempt) {
+          this.state = "HALF_OPEN";
+          await this.persist();
+        }
+
+        Metrics.circuitBreakerState(this.state);
+        logger.info(
+          {
+            state: this.state,
+            failureCount: this.failureCount,
+            nextAttempt: this.nextAttempt ? new Date(this.nextAttempt).toISOString() : null,
+          },
+          "Circuit breaker state restored",
+        );
+      })
+      .catch((err) => {
+        logger.error({ err }, "Failed to restore circuit breaker state");
+      });
+    await this.initialized;
+  }
+
+  private async setState(state: State): Promise<void> {
+    this.state = state;
+    if (state === "CLOSED") {
+      this.nextAttempt = 0;
+    }
+    await this.persist();
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.storage) return;
+    await this.storage.save({
+      state: this.state,
+      failureCount: this.failureCount,
+      nextAttempt: this.nextAttempt,
+    });
   }
 }

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -22,7 +22,7 @@ export async function processDueRecurringSupports(prismaClient = prisma) {
     // Mark the subscription cancelled so it stops appearing as due and so
     // the profile owner can see the cancellation in their dashboard.
     if (!support.supporter) {
-      await prisma.recurringSupport.update({
+      await prismaClient.recurringSupport.update({
         where: { id: support.id },
         data: { status: "cancelled", cancelledAt: new Date() },
       });
@@ -84,22 +84,54 @@ export async function processDueRecurringSupports(prismaClient = prisma) {
   }
 }
 
-export function startDripScheduler() {
+export type SchedulerHandle = {
+  stop(): Promise<void>;
+};
+
+let dripInterval: ReturnType<typeof setInterval> | null = null;
+let dripInFlight: Promise<void> | null = null;
+let dripStopped = true;
+
+function runDripSchedulerTick(): void {
+  dripInFlight = processDueRecurringSupports()
+    .catch((err) => {
+      logger.error({ err }, "Error in processDueRecurringSupports run");
+    })
+    .finally(() => {
+      dripInFlight = null;
+    });
+}
+
+export function startDripScheduler(): SchedulerHandle {
   if (process.env.DRIP_SCHEDULER_ENABLED === "true") {
     logger.info("Drip scheduler enabled. Starting...");
+    dripStopped = false;
     
     // Initial run
-    processDueRecurringSupports().catch((err) => {
-      logger.error({ err }, "Error in initial processDueRecurringSupports run");
-    });
+    runDripSchedulerTick();
     
     // Then every 60 seconds
-    setInterval(() => {
-      processDueRecurringSupports().catch((err) => {
-        logger.error({ err }, "Error in processDueRecurringSupports interval");
-      });
+    dripInterval = setInterval(() => {
+      if (!dripInFlight) {
+        runDripSchedulerTick();
+      }
     }, 60000);
   } else {
     logger.info("Drip scheduler disabled.");
   }
+
+  return {
+    async stop() {
+      if (dripStopped) return;
+      dripStopped = true;
+      if (dripInterval) {
+        clearInterval(dripInterval);
+        dripInterval = null;
+      }
+      if (dripInFlight) {
+        await dripInFlight;
+      }
+      logger.info("Drip scheduler stopped.");
+    },
+  };
 }

--- a/backend/src/services/event-indexer.ts
+++ b/backend/src/services/event-indexer.ts
@@ -94,6 +94,7 @@ export class EventIndexer {
   private readonly maxPagesPerTick: number;
   private stopped = false;
   private timer: NodeJS.Timeout | null = null;
+  private currentTick: Promise<void> | null = null;
 
   constructor(options: EventIndexerOptions) {
     this.prisma = options.prisma;
@@ -110,11 +111,14 @@ export class EventIndexer {
     this.scheduleNextTick(0);
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.stopped = true;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
+    }
+    if (this.currentTick) {
+      await this.currentTick;
     }
   }
 
@@ -305,9 +309,14 @@ export class EventIndexer {
   private scheduleNextTick(delayMs: number): void {
     if (this.stopped) return;
     this.timer = setTimeout(() => {
-      this.tick().catch((err) => {
-        logger.error({ err }, "event indexer tick failed");
-      });
+      this.timer = null;
+      this.currentTick = this.tick()
+        .catch((err) => {
+          logger.error({ err }, "event indexer tick failed");
+        })
+        .finally(() => {
+          this.currentTick = null;
+        });
     }, delayMs);
   }
 

--- a/backend/src/services/webhook-processor.ts
+++ b/backend/src/services/webhook-processor.ts
@@ -83,14 +83,48 @@ export async function processPendingWebhookDeliveries() {
   }
 }
 
-export function startWebhookProcessor() {
+export type WebhookProcessorHandle = {
+  stop(): Promise<void>;
+};
+
+let processorInterval: ReturnType<typeof setInterval> | null = null;
+let processorInFlight: Promise<void> | null = null;
+let processorStopped = true;
+
+function runWebhookProcessorTick(): void {
+  processorInFlight = processPendingWebhookDeliveries()
+    .catch((err) => {
+      logger.error({ err }, "Error in webhook processor run");
+    })
+    .finally(() => {
+      processorInFlight = null;
+    });
+}
+
+export function startWebhookProcessor(): WebhookProcessorHandle {
   const interval = Number(process.env.WEBHOOK_PROCESSOR_INTERVAL_MS ?? 10000);
 
   logger.info({ interval }, "Starting webhook processor...");
+  processorStopped = false;
 
-  setInterval(() => {
-    processPendingWebhookDeliveries().catch((err) => {
-      logger.error({ err }, "Error in webhook processor interval");
-    });
+  processorInterval = setInterval(() => {
+    if (!processorInFlight) {
+      runWebhookProcessorTick();
+    }
   }, interval);
+
+  return {
+    async stop() {
+      if (processorStopped) return;
+      processorStopped = true;
+      if (processorInterval) {
+        clearInterval(processorInterval);
+        processorInterval = null;
+      }
+      if (processorInFlight) {
+        await processorInFlight;
+      }
+      logger.info("Webhook processor stopped.");
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- Add graceful shutdown handling for the event indexer, drip scheduler, webhook processor, weekly digest scheduler, HTTP server, Prisma, and Sentry.
- Route pagination limits through Zod validation instead of raw `parseInt` in the remaining backend endpoints.
- Centralize profile ownership checks so wallet-address JWTs and userId JWTs follow the same fallback strategy.
- Persist Horizon circuit breaker state in Postgres so OPEN/HALF_OPEN/CLOSED state survives restarts.

## Validation
- `DATABASE_URL=postgresql://user:pass@localhost:5432/novasupport DIRECT_URL=postgresql://user:pass@localhost:5432/novasupport npm run db:generate`
- `npm run build`
- `npm run lint` (passes with existing warnings)
- `NODE_ENV=test JWT_SECRET=test-secret npx tsx src/services/circuit-breaker.test.ts`
- `NODE_ENV=test JWT_SECRET=test-secret npx tsx src/services/drip-scheduler.test.ts`
- `DATABASE_URL=postgresql://novasupport:novasupport@localhost:5432/novasupport DIRECT_URL=postgresql://novasupport:novasupport@localhost:5432/novasupport npm run db:migrate:deploy`
- `DATABASE_URL=postgresql://novasupport:novasupport@localhost:5432/novasupport DIRECT_URL=postgresql://novasupport:novasupport@localhost:5432/novasupport SKIP_HORIZON_VALIDATION=true git push -u origin codex/backend-resilience-pagination-auth-breaker` (pre-push backend tests passed)

Closes #576.
Closes #581.
Closes #582.
Closes #583.
