### PR TITLE
fix: resolve #584 #585 #586 #587 — webhook jitter, canonical sigs, re…

### DIFF
--- a/backend/prisma/migrations/20260624030000_add_recurring_support_execution/migration.sql
+++ b/backend/prisma/migrations/20260624030000_add_recurring_support_execution/migration.sql
@@ -1,0 +1,37 @@
+-- AlterTable: Add supporterAddress to RecurringSupport
+ALTER TABLE "RecurringSupport" ADD COLUMN "supporterAddress" TEXT;
+
+-- Populate supporterAddress from User.email for existing records
+UPDATE "RecurringSupport" rs
+SET "supporterAddress" = u.email
+FROM "User" u
+WHERE rs."supporterId" = u.id;
+
+-- CreateTable
+CREATE TABLE "RecurringSupportExecution" (
+    "id" TEXT NOT NULL,
+    "recurringSupportId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecurringSupportExecution_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "SupportTransaction" ADD COLUMN "recurringSupportExecutionId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SupportTransaction_recurringSupportExecutionId_key" ON "SupportTransaction"("recurringSupportExecutionId");
+
+-- CreateIndex
+CREATE INDEX "RecurringSupportExecution_recurringSupportId_idx" ON "RecurringSupportExecution"("recurringSupportId");
+
+-- CreateIndex
+CREATE INDEX "RecurringSupportExecution_status_idx" ON "RecurringSupportExecution"("status");
+
+-- AddForeignKey
+ALTER TABLE "RecurringSupportExecution" ADD CONSTRAINT "RecurringSupportExecution_recurringSupportId_fkey" FOREIGN KEY ("recurringSupportId") REFERENCES "RecurringSupport"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SupportTransaction" ADD CONSTRAINT "SupportTransaction_recurringSupportExecutionId_fkey" FOREIGN KEY ("recurringSupportExecutionId") REFERENCES "RecurringSupportExecution"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -95,6 +95,8 @@ model SupportTransaction {
   updatedAt        DateTime  @updatedAt
   profile          Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
   supporter        User?     @relation("SupporterTransactions", fields: [supporterId], references: [id], onDelete: SetNull)
+  recurringSupportExecutionId String? @unique
+  recurringSupportExecution   RecurringSupportExecution? @relation(fields: [recurringSupportExecutionId], references: [id], onDelete: SetNull)
 
   @@index([profileId])
   @@index([supporterId])
@@ -189,17 +191,33 @@ model RecurringSupport {
   cancelledAt DateTime?
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
+  supporterAddress String?
   // #608: onDelete: SetNull preserves subscription history when the supporter's
   // User row is deleted. supporterId becomes NULL; the drip-scheduler detects
   // this on its next run and writes status = 'cancelled' + cancelledAt.
   supporter   User?     @relation("RecurringSupporters", fields: [supporterId], references: [id], onDelete: SetNull)
   profile     Profile   @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  executions  RecurringSupportExecution[]
 
   @@index([supporterId])
   @@index([profileId])
   @@index([nextRunAt])
   @@index([nextRunAt, status])
 }
+
+model RecurringSupportExecution {
+  id                 String           @id @default(cuid())
+  recurringSupportId String
+  status             String           @default("pending") // "pending", "success", "failed"
+  createdAt          DateTime         @default(now())
+  updatedAt          DateTime         @updatedAt
+  recurringSupport   RecurringSupport @relation(fields: [recurringSupportId], references: [id], onDelete: Cascade)
+  supportTransaction SupportTransaction?
+
+  @@index([recurringSupportId])
+  @@index([status])
+}
+
 
 // #281: cursor record for the contract event indexer.
 // One row per (network, contractId) pair. The indexer reads the cursor on

--- a/backend/src/app.test.ts
+++ b/backend/src/app.test.ts
@@ -454,7 +454,7 @@ async function main() {
 
   // Test 20: URL sanitization and validation
   await runTest("sanitizeString normalizes and validates URLs", async () => {
-    // Valid URL normalization
+    // Valid URL normalization — bare domains get https:// prefix and canonical trailing slash
     const { result: result1 } = sanitizeString("websiteUrl", "example.com");
     assert.equal(result1, "https://example.com/");
 
@@ -677,7 +677,8 @@ async function main() {
     await new Promise<void>((resolve) => sanitizeQuery(req, res, resolve as Parameters<typeof sanitizeQuery>[2]));
     
     const query = req.query as Record<string, unknown>;
-    assert.deepEqual(query.tags, ["tag1", "tag2", "tag3"]);
+    // sanitize-html strips <script> content entirely for safety — confirmed empty
+    assert.deepEqual(query.tags, ["tag1", "", "tag3"]);
     assert.equal(query.single, "value");
   });
 
@@ -1220,6 +1221,116 @@ async function main() {
       else process.env.SKIP_HORIZON_VALIDATION = prev;
     }
   });
+
+  // Test 42b: POST /support-transactions with recurringSupportExecutionId
+  if (hasDb) {
+    await runTest("POST /support-transactions with recurringSupportExecutionId validates details and updates status", async () => {
+      const srv = await startTestServer(makeLogStream().stream);
+      const prevSkip = process.env.SKIP_HORIZON_VALIDATION;
+      process.env.SKIP_HORIZON_VALIDATION = "true";
+
+      let userId: string | undefined;
+      let profileId: string | undefined;
+      let recurringId: string | undefined;
+      let executionId: string | undefined;
+
+      try {
+        const testWallet = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        const user = await prisma.user.create({ data: { email: testWallet } });
+        userId = user.id;
+        const token = signJWT(testWallet, user.id);
+
+        const profile = await prisma.profile.create({
+          data: {
+            username: `recur-exec-${randomUUID().slice(0, 8)}`,
+            displayName: "Recur Exec Test",
+            bio: "",
+            walletAddress: testWallet,
+            ownerId: user.id,
+            acceptedAssets: { create: [{ code: "XLM" }] },
+          },
+        });
+        profileId = profile.id;
+
+        const nextRunAt = new Date();
+        const support = await prisma.recurringSupport.create({
+          data: {
+            supporterId: user.id,
+            supporterAddress: testWallet,
+            profileId,
+            amount: "10.0000000",
+            assetCode: "XLM",
+            frequency: "monthly",
+            nextRunAt,
+          },
+        });
+        recurringId = support.id;
+
+        const execution = await prisma.recurringSupportExecution.create({
+          data: {
+            recurringSupportId: support.id,
+            status: "pending",
+          },
+        });
+        executionId = execution.id;
+
+        // Try with mismatching details
+        const mismatchRes = await fetch(`${srv.baseUrl}/support-transactions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            txHash: `exec-test-mismatch-${randomUUID()}`,
+            amount: "5.0000000", // should be 10.0000000
+            assetCode: "XLM",
+            recipientAddress: testWallet,
+            profileId,
+            stellarNetwork: "TESTNET",
+            recurringSupportExecutionId: executionId,
+          }),
+        });
+        assert.equal(mismatchRes.status, 400, `Expected 400 for mismatch, got ${mismatchRes.status}`);
+
+        // Try with matching details
+        const matchRes = await fetch(`${srv.baseUrl}/support-transactions`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            txHash: `exec-test-match-${randomUUID()}`,
+            amount: "10.0000000",
+            assetCode: "XLM",
+            recipientAddress: testWallet,
+            profileId,
+            stellarNetwork: "TESTNET",
+            recurringSupportExecutionId: executionId,
+          }),
+        });
+        assert.equal(matchRes.status, 200, `Expected 200/201, got ${matchRes.status}`);
+
+        const execCheck = await prisma.recurringSupportExecution.findUnique({
+          where: { id: executionId },
+        });
+        assert.equal(execCheck?.status, "success", "Execution status should be updated to success");
+      } finally {
+        await srv.close();
+        if (prevSkip === undefined) delete process.env.SKIP_HORIZON_VALIDATION;
+        else process.env.SKIP_HORIZON_VALIDATION = prevSkip;
+
+        if (executionId) await prisma.recurringSupportExecution.deleteMany({ where: { id: executionId } });
+        if (recurringId) await prisma.recurringSupport.deleteMany({ where: { id: recurringId } });
+        if (profileId) {
+          await prisma.acceptedAsset.deleteMany({ where: { profileId } });
+          await prisma.profile.deleteMany({ where: { id: profileId } });
+        }
+        if (userId) await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    });
+  }
 
   // ── Issue #447: Leaderboard caching ──────────────────────────────────
   if (hasDb) {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2330,6 +2330,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     recipientAddress: z.string().min(1),
     profileId: z.string().min(1),
     supporterId: z.string().optional().nullable(),
+    recurringSupportExecutionId: z.string().optional().nullable(),
   });
 
   async function verifyTransaction(
@@ -3088,12 +3089,39 @@ All errors return JSON with an \`error\` field and optional \`code\`:
           });
       }
 
+      if (parsed.data.recurringSupportExecutionId) {
+        const execution = await prisma.recurringSupportExecution.findUnique({
+          where: { id: parsed.data.recurringSupportExecutionId },
+          include: { recurringSupport: { include: { profile: true } } },
+        });
+        if (!execution) {
+          return sendError(res, 404, "Recurring support execution not found");
+        }
+        if (execution.status !== "pending") {
+          return sendError(res, 400, "Recurring support execution is not pending");
+        }
+        if (
+          new Decimal(execution.recurringSupport.amount).toString() !== new Decimal(parsed.data.amount).toString() ||
+          execution.recurringSupport.assetCode !== parsed.data.assetCode ||
+          execution.recurringSupport.profile.walletAddress !== parsed.data.recipientAddress
+        ) {
+          return sendError(res, 400, "Transaction details do not match recurring support subscription");
+        }
+      }
+
       let supportRecord;
       try {
         supportRecord = await prisma.$transaction(async (tx: any) => {
           const record = await tx.supportTransaction.create({
             data: parsed.data,
           });
+
+          if (parsed.data.recurringSupportExecutionId) {
+            await tx.recurringSupportExecution.update({
+              where: { id: parsed.data.recurringSupportExecutionId },
+              data: { status: "success" },
+            });
+          }
 
           if (parsed.data.status === "SUCCESS") {
             const milestones = await tx.milestone.findMany({
@@ -3991,6 +4019,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     await prisma.recurringSupport.create({
       data: {
         supporterId: user.id,
+        supporterAddress: req.auth!.walletAddress,
         profileId,
         amount,
         assetCode,

--- a/backend/src/middleware/sanitize.ts
+++ b/backend/src/middleware/sanitize.ts
@@ -97,7 +97,17 @@ function normalizeUrl(value: string): { url: string | null; violations: string[]
   try {
     // Add protocol if missing, but validate the original format first
     let urlString = value;
-    
+
+    // Block non-http(s) schemes that may not contain "://" (e.g. javascript:, data:)
+    const colonIdx = value.indexOf(":");
+    if (colonIdx !== -1) {
+      const scheme = value.slice(0, colonIdx).toLowerCase().trim();
+      if (scheme !== "http" && scheme !== "https" && !/^\s*$/.test(scheme)) {
+        violations.push("Only HTTP and HTTPS protocols are allowed");
+        return { url: null, violations };
+      }
+    }
+
     // Check for invalid protocols in the original string
     if (value.includes("://")) {
       const protocol = value.split("://")[0].toLowerCase();
@@ -105,7 +115,7 @@ function normalizeUrl(value: string): { url: string | null; violations: string[]
         violations.push("Only HTTP and HTTPS protocols are allowed");
         return { url: null, violations };
       }
-    } else {
+    } else if (colonIdx === -1) {
       // Add https if no protocol
       urlString = `https://${urlString}`;
     }
@@ -138,10 +148,8 @@ function normalizeUrl(value: string): { url: string | null; violations: string[]
       return { url: null, violations };
     }
 
-    // url.href adds a trailing slash to bare origins (e.g. "https://stellar.example/").
-    // Strip it only when the original had no path and no trailing slash.
-    const href = url.pathname === "/" && !value.endsWith("/") ? url.href.slice(0, -1) : url.href;
-    return { url: href, violations };
+    // Always return the canonical href (with trailing slash for bare origins).
+    return { url: url.href, violations };
   } catch (error) {
     violations.push("Invalid URL format");
     return { url: null, violations };
@@ -330,6 +338,13 @@ export function sanitizeObject(
   if (Array.isArray(obj)) {
     let changed = false;
     const result = obj.map((item, index) => {
+      if (typeof item === "string") {
+        // Use a generic key so HTML sanitization still applies
+        const { result: r, changed: c, violations } = sanitizeString("message", item);
+        if (c) changed = true;
+        allViolations.push(...violations.map(v => `[${index}] ${v}`));
+        return r;
+      }
       const { result: r, changed: c, violations } = sanitizeObject(item, depth + 1);
       if (c) changed = true;
       allViolations.push(...violations.map(v => `[${index}] ${v}`));

--- a/backend/src/services/drip-scheduler.test.ts
+++ b/backend/src/services/drip-scheduler.test.ts
@@ -44,7 +44,7 @@ function buildPrismaMock(overrides: {
   recurringSupports?: unknown[];
 } = {}) {
   const txRecurringSupportUpdate = mock.fn(() => Promise.resolve({}));
-  const txSupportTransactionCreate = mock.fn(() => Promise.resolve({}));
+  const txRecurringSupportExecutionCreate = mock.fn(() => Promise.resolve({}));
 
   const recurringSupportFindMany = mock.fn(() =>
     Promise.resolve(overrides.recurringSupports ?? [makeSupport()]),
@@ -52,7 +52,7 @@ function buildPrismaMock(overrides: {
 
   const $transaction = mock.fn((cb: (tx: unknown) => Promise<void>) => {
     const tx = {
-      supportTransaction: { create: txSupportTransactionCreate },
+      recurringSupportExecution: { create: txRecurringSupportExecutionCreate },
       recurringSupport: { update: txRecurringSupportUpdate },
     };
     return cb(tx);
@@ -61,7 +61,7 @@ function buildPrismaMock(overrides: {
   return {
     recurringSupport: { findMany: recurringSupportFindMany },
     $transaction,
-    txSupportTransactionCreate,
+    txRecurringSupportExecutionCreate,
     txRecurringSupportUpdate,
   };
 }
@@ -73,12 +73,11 @@ test("processDueRecurringSupports processes active due supports", async () => {
 
   assert.equal(mockPrisma.recurringSupport.findMany.mock.callCount(), 1);
   assert.equal(mockPrisma.$transaction.mock.callCount(), 1);
-  assert.equal(mockPrisma.txSupportTransactionCreate.mock.callCount(), 1);
+  assert.equal(mockPrisma.txRecurringSupportExecutionCreate.mock.callCount(), 1);
 
-  const createCall = getFirstArg<TxCreateArg>(mockPrisma.txSupportTransactionCreate);
-  assert.match(createCall.data.txHash as string, /^pending_/);
+  const createCall = getFirstArg<TxCreateArg>(mockPrisma.txRecurringSupportExecutionCreate);
+  assert.equal(createCall.data.recurringSupportId, "drip-1");
   assert.equal(createCall.data.status, "pending");
-  assert.equal(createCall.data.recipientAddress, "GAAAA");
 });
 
 test("processDueRecurringSupports advances nextRunAt for weekly frequency", async () => {
@@ -131,7 +130,7 @@ test("processDueRecurringSupports continues processing after individual failure"
   const $transaction = mock.fn((cb: (tx: unknown) => Promise<void>) => {
     callIndex++;
     const tx = {
-      supportTransaction: { create: mock.fn(() => Promise.resolve({})) },
+      recurringSupportExecution: { create: mock.fn(() => Promise.resolve({})) },
       recurringSupport: { update: mock.fn(() => Promise.resolve({})) },
     };
     const result = cb(tx);
@@ -153,26 +152,6 @@ test("processDueRecurringSupports continues processing after individual failure"
   await processDueRecurringSupports(mockPrisma as any);
 
   assert.equal($transaction.mock.callCount(), 2);
-});
-
-test("processDueRecurringSupports creates pending txHash in correct format", async () => {
-  const mockPrisma = buildPrismaMock();
-
-  await processDueRecurringSupports(mockPrisma as any);
-
-  const createCall = getFirstArg<TxCreateArg>(mockPrisma.txSupportTransactionCreate);
-  assert.match(createCall.data.txHash as string, /^pending_[0-9a-f-]{36}$/);
-});
-
-test("processDueRecurringSupports sets correct asset code from support", async () => {
-  const mockPrisma = buildPrismaMock({
-    recurringSupports: [makeSupport({ assetCode: "USDC" })],
-  });
-
-  await processDueRecurringSupports(mockPrisma as any);
-
-  const createCall = getFirstArg<TxCreateArg>(mockPrisma.txSupportTransactionCreate);
-  assert.equal(createCall.data.assetCode, "USDC");
 });
 
 test("processDueRecurringSupports filters for active status with due nextRunAt", async () => {

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -42,21 +42,11 @@ export async function processDueRecurringSupports(prismaClient = prisma) {
       }
 
       await prismaClient.$transaction(async (tx: any) => {
-        // Create the pending SupportTransaction
-        const txHash = `pending_${crypto.randomUUID()}`;
-
-        await tx.supportTransaction.create({
+        // Create the pending RecurringSupportExecution
+        await tx.recurringSupportExecution.create({
           data: {
-            txHash,
-            amount: support.amount,
-            assetCode: support.assetCode,
+            recurringSupportId: support.id,
             status: "pending",
-            message: `Recurring support (${support.frequency})`,
-            stellarNetwork: "TESTNET",
-            recipientAddress: support.profile.walletAddress,
-            profileId: support.profileId,
-            supporterId: support.supporterId,
-            supporterAddress: supporter.email,
           },
         });
 

--- a/backend/src/services/webhook.ts
+++ b/backend/src/services/webhook.ts
@@ -10,8 +10,23 @@ export type DeliveryResult =
   | { status: "success"; statusCode: number }
   | { status: "failed"; error: string; willRetry: boolean; nextRetryDelayMs?: number };
 
+export function canonicalJsonStringify(val: unknown): string {
+  if (val === null || typeof val !== "object") {
+    return JSON.stringify(val);
+  }
+  if (Array.isArray(val)) {
+    return "[" + val.map(canonicalJsonStringify).join(",") + "]";
+  }
+  const keys = Object.keys(val as Record<string, unknown>).sort();
+  const parts = keys.map((key) => {
+    const value = (val as Record<string, unknown>)[key];
+    return JSON.stringify(key) + ":" + canonicalJsonStringify(value);
+  });
+  return "{" + parts.join(",") + "}";
+}
+
 export function generateSignature(secret: string, payload: WebhookPayload): string {
-  const payloadString = JSON.stringify(payload);
+  const payloadString = canonicalJsonStringify(payload);
   return createHmac("sha256", secret).update(payloadString).digest("hex");
 }
 
@@ -36,7 +51,7 @@ export async function deliverWebhook(
   signal?: AbortSignal,
 ): Promise<DeliveryResult> {
   const signature = generateSignature(secret, payload);
-  const payloadString = JSON.stringify(payload);
+  const payloadString = canonicalJsonStringify(payload);
 
   const timeoutSignal = AbortSignal.timeout(DELIVERY_TIMEOUT_MS);
   const mergedSignal = signal
@@ -83,7 +98,9 @@ export async function deliverWebhook(
 
 export function getNextRetryDelay(attemptCount: number): number | null {
   if (attemptCount >= BACKOFF_SCHEDULE_SECONDS.length) return null;
-  return BACKOFF_SCHEDULE_SECONDS[attemptCount] * 1000;
+  const baseMs = BACKOFF_SCHEDULE_SECONDS[attemptCount] * 1000;
+  const jitterPercent = (Math.random() * 40 - 20) / 100;
+  return Math.round(baseMs * (1 + jitterPercent));
 }
 
 export function shouldRetry(attemptCount: number): boolean {

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,45 @@
+## What does this PR do?
+
+This PR resolves four backend reliability and security issues (#584 – #587):
+
+1. **#584 — Webhook retry jitter** (`src/services/webhook.ts`): Added ±20 % random jitter to `getNextRetryDelay()` so retries after a mass failure are spread across a window instead of all firing at the same instant (thundering-herd prevention).
+
+2. **#585 — Canonical webhook signatures** (`src/services/webhook.ts`): Introduced `canonicalJsonStringify()` — a recursive, alphabetically-key-sorted JSON serialiser — and switched both `generateSignature()` and the payload body in `deliverWebhook()` to use it. Subscriber verification is now deterministic regardless of Node version or middleware insertion order.
+
+3. **#586 — Separate recurring-support execution table** (`prisma/schema.prisma`, `src/services/drip-scheduler.ts`, `src/app.ts`): Instead of recording a fake `txHash = 'pending_…'` row in `SupportTransaction`, the drip scheduler now creates a `RecurringSupportExecution` row (status: `pending`). When the user later submits the real Stellar transaction via `POST /support-transactions`, the endpoint validates the execution details match the subscription and atomically marks it `success`. This keeps `SupportTransaction` clean and audit-ready.
+
+4. **#587 — Stellar address as supporterAddress** (`prisma/schema.prisma`, `src/app.ts`): Added `supporterAddress` to `RecurringSupport` and now populate it from `req.auth!.walletAddress` (the verified Stellar public key), not `user.email`. Schema is resilient to future email/wallet-address separation.
+
+### Supporting changes
+- `drip-scheduler.test.ts` rewritten to cover the new `recurringSupportExecution.create` path (6 tests, all pass).
+- `app.test.ts`: added Test 42b — integration test for `recurringSupportExecutionId` validation; corrected URL-normalisation and sanitize-array expectations.
+- `src/middleware/sanitize.ts`: fixed `javascript:` / `data:` scheme blocking, normalised URLs to always return canonical `href` (with trailing slash), and enabled HTML sanitization for plain strings inside sanitised arrays.
+
+## Related issue
+
+Closes #584, #585, #586, #587
+
+## Type of change
+
+- [x] Bug fix
+- [ ] New feature
+- [x] Refactor
+- [ ] Docs / config only
+
+## How to test
+
+1. **Webhook jitter**: Call `getNextRetryDelay(0)` (1 s base) multiple times — values will vary within [800 ms, 1 200 ms].
+2. **Canonical signatures**: Sign a payload with keys in arbitrary order; verify with keys in a different order — HMAC should always match.
+3. **Recurring execution flow**:
+   - `POST /recurring-support` to create a subscription.
+   - Inspect the drip-scheduler log — no `SupportTransaction` row is created; a `RecurringSupportExecution` row with `status = pending` appears instead.
+   - `POST /support-transactions` with `recurringSupportExecutionId` — mismatched amount/asset/recipient returns `400`; matching details succeed and mark the execution `success`.
+4. **Run tests**: `npm test` in `backend/` — all tests pass (DB-dependent tests require `DATABASE_URL`).
+
+## Checklist
+
+- [x] I have read the CONTRIBUTING guide
+- [x] My branch is up to date with main
+- [x] Linter passes (`npm run lint`)
+- [x] Tests pass (`npm test`) if applicable
+- [x] I have not committed `.env` files or secrets


### PR DESCRIPTION
## What does this PR do?

This PR resolves four backend reliability and security issues (#584 – #587):

1. **#584 — Webhook retry jitter** (`src/services/webhook.ts`): Added ±20 % random jitter to `getNextRetryDelay()` so retries after a mass failure are spread across a window instead of all firing at the same instant (thundering-herd prevention).

2. **#585 — Canonical webhook signatures** (`src/services/webhook.ts`): Introduced `canonicalJsonStringify()` — a recursive, alphabetically-key-sorted JSON serialiser — and switched both `generateSignature()` and the payload body in `deliverWebhook()` to use it. Subscriber verification is now deterministic regardless of Node version or middleware insertion order.

3. **#586 — Separate recurring-support execution table** (`prisma/schema.prisma`, `src/services/drip-scheduler.ts`, `src/app.ts`): Instead of recording a fake `txHash = 'pending_…'` row in `SupportTransaction`, the drip scheduler now creates a `RecurringSupportExecution` row (status: `pending`). When the user later submits the real Stellar transaction via `POST /support-transactions`, the endpoint validates the execution details match the subscription and atomically marks it `success`. This keeps `SupportTransaction` clean and audit-ready.

4. **#587 — Stellar address as supporterAddress** (`prisma/schema.prisma`, `src/app.ts`): Added `supporterAddress` to `RecurringSupport` and now populate it from `req.auth!.walletAddress` (the verified Stellar public key), not `user.email`. Schema is resilient to future email/wallet-address separation.

### Supporting changes
- `drip-scheduler.test.ts` rewritten to cover the new `recurringSupportExecution.create` path (6 tests, all pass).
- `app.test.ts`: added Test 42b — integration test for `recurringSupportExecutionId` validation; corrected URL-normalisation and sanitize-array expectations.
- `src/middleware/sanitize.ts`: fixed `javascript:` / `data:` scheme blocking, normalised URLs to always return canonical `href` (with trailing slash), and enabled HTML sanitization for plain strings inside sanitised arrays.

## Related issue

Closes #584, Closes #585, Closes #586, Closes #587

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs / config only

## How to test

1. **Webhook jitter**: Call `getNextRetryDelay(0)` (1 s base) multiple times — values will vary within [800 ms, 1 200 ms].
2. **Canonical signatures**: Sign a payload with keys in arbitrary order; verify with keys in a different order — HMAC should always match.
3. **Recurring execution flow**:
   - `POST /recurring-support` to create a subscription.
   - Inspect the drip-scheduler log — no `SupportTransaction` row is created; a `RecurringSupportExecution` row with `status = pending` appears instead.
   - `POST /support-transactions` with `recurringSupportExecutionId` — mismatched amount/asset/recipient returns `400`; matching details succeed and mark the execution `success`.
4. **Run tests**: `npm test` in `backend/` — all tests pass (DB-dependent tests require `DATABASE_URL`).

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My branch is up to date with main
- [x] Linter passes (`npm run lint`)
- [x] Tests pass (`npm test`) if applicable
- [x] I have not committed `.env` files or secrets