### PR TITLE
Fix stale activity-feed requests, double-submit on create, drip month drift, and stale support balance

### DIFF
--- a/backend/src/services/drip-scheduler.test.ts
+++ b/backend/src/services/drip-scheduler.test.ts
@@ -109,11 +109,34 @@ test("processDueRecurringSupports advances nextRunAt for monthly frequency", asy
   const updateCall = getFirstArg<TxUpdateArg>(mockPrisma.txRecurringSupportUpdate);
   const now = new Date();
   const expectedNext = new Date(now);
-  expectedNext.setDate(expectedNext.getDate() + 30);
+  expectedNext.setMonth(expectedNext.getMonth() + 1);
   assert.ok(
     Math.abs(updateCall.data.nextRunAt.getTime() - expectedNext.getTime()) < 2000,
-    `nextRunAt should be ~30 days from now`,
+    `nextRunAt should be ~1 calendar month from now`,
   );
+});
+
+// ── Month-boundary regression test (issue #645) ──────────────────────────────
+
+test("processDueRecurringSupports does not overflow into the wrong month at month-end boundaries", async () => {
+  const jan31 = new Date(Date.UTC(2024, 0, 31, 12, 0, 0));
+  const mockPrisma = buildPrismaMock({
+    recurringSupports: [makeSupport({ frequency: "monthly", nextRunAt: jan31 })],
+  });
+
+  const originalNow = Date.now;
+  Date.now = () => jan31.getTime();
+  try {
+    await processDueRecurringSupports(mockPrisma as any);
+  } finally {
+    Date.now = originalNow;
+  }
+
+  const updateCall = getFirstArg<TxUpdateArg>(mockPrisma.txRecurringSupportUpdate);
+  // Jan 31 + 1 month should clamp to Feb 29 (2024 is a leap year), not roll
+  // over into March as `setDate(getDate() + 30)` used to.
+  assert.equal(updateCall.data.nextRunAt.getUTCMonth(), 1, "should land in February, not March");
+  assert.equal(updateCall.data.nextRunAt.getUTCDate(), 29);
 });
 
 test("processDueRecurringSupports no-ops when no due supports exist", async () => {

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -5,6 +5,19 @@ import { Metrics } from "../metrics.js";
 
 const DRIP_BATCH_SIZE = 100;
 
+function addMonths(date: Date, months: number): Date {
+  const result = new Date(date);
+  const targetMonth = result.getMonth() + months;
+  result.setMonth(targetMonth);
+  // setMonth overflows into the next month when the day doesn't exist
+  // there (e.g. Jan 31 + 1 month -> Mar 3). Clamp to the last day of
+  // the target month instead.
+  if (result.getMonth() !== ((targetMonth % 12) + 12) % 12) {
+    result.setDate(0);
+  }
+  return result;
+}
+
 export async function processDueRecurringSupports(prismaClient = prisma) {
   const now = new Date();
   let cursor: string | undefined;
@@ -42,13 +55,10 @@ export async function processDueRecurringSupports(prismaClient = prisma) {
     try {
       const supporter = support.supporter;
       // Calculate nextRunAt based on frequency
-      const nextRunAt = new Date(now);
-      if (support.frequency === "weekly") {
-        nextRunAt.setDate(nextRunAt.getDate() + 7);
-      } else {
-        // Default to monthly (30 days)
-        nextRunAt.setDate(nextRunAt.getDate() + 30);
-      }
+      const nextRunAt =
+        support.frequency === "weekly"
+          ? new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+          : addMonths(now, 1);
 
       await prismaClient.$transaction(async (tx: any) => {
         // Create the pending RecurringSupportExecution

--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -173,6 +173,8 @@ export default function CreatePage() {
   };
 
   async function handleSubmit() {
+    if (loading) return;
+
     setError(null);
     setFieldErrors({ username: null, email: null });
 
@@ -564,8 +566,11 @@ export default function CreatePage() {
                 type="button"
                 onClick={handleSubmit}
                 disabled={loading || rateLimited}
-                className="flex-[2] rounded-full bg-mint px-5 py-4 text-sm font-semibold text-ink transition hover:bg-white active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-[2] flex items-center justify-center gap-2 rounded-full bg-mint px-5 py-4 text-sm font-semibold text-ink transition hover:bg-white active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
               >
+                {loading && (
+                  <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-ink border-t-transparent" />
+                )}
                 {rateLimited
                   ? `Try again in ${rateLimitRemainingMinutes} minute${rateLimitRemainingMinutes === 1 ? "" : "s"}`
                   : loading

--- a/frontend/src/components/activity-feed.tsx
+++ b/frontend/src/components/activity-feed.tsx
@@ -83,18 +83,20 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
   const [hasMore, setHasMore] = useState(false);
 
   useEffect(() => {
-    fetchActivities();
+    const controller = new AbortController();
+    fetchActivities(controller.signal);
+    return () => controller.abort();
   }, [username]);
 
-  async function fetchActivities() {
+  async function fetchActivities(signal?: AbortSignal) {
     try {
       setLoading(true);
       setError(null);
       setMilestonesUnavailable(false);
 
       const [transactionsRes, milestonesRes] = await Promise.all([
-        fetch(`${API_BASE_URL}/profiles/${username}/transactions?limit=100`),
-        fetch(`${API_BASE_URL}/profiles/${username}/milestones`).catch(() => null),
+        fetch(`${API_BASE_URL}/profiles/${username}/transactions?limit=100`, { signal }),
+        fetch(`${API_BASE_URL}/profiles/${username}/milestones`, { signal }).catch(() => null),
       ]);
 
       const transactionsData = transactionsRes.ok
@@ -159,10 +161,11 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
       setActivities(items);
       setHasMore(items.length > limit);
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       console.error("Failed to fetch activities:", err);
       setError("Failed to load activity feed");
     } finally {
-      setLoading(false);
+      if (!signal?.aborted) setLoading(false);
     }
   }
 
@@ -200,7 +203,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
           <AlertTriangle className="h-4 w-4 flex-shrink-0" />
           <span>Milestone data could not be loaded — the feed may be incomplete.</span>
           <button
-            onClick={fetchActivities}
+            onClick={() => fetchActivities()}
             className="ml-auto flex-shrink-0 text-xs underline underline-offset-2 hover:text-yellow-300 transition"
           >
             Retry

--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -154,6 +154,8 @@ export function SupportPanel({
           // Non-critical — recurring registration failure doesn't affect the payment.
         });
       }
+
+      await loadBalance(visitorAddress);
     } catch (err: unknown) {
       showToast(mapWalletError(err), "error");
     } finally {


### PR DESCRIPTION
## Summary

Four small, independent bug fixes across frontend and backend:

- **#648 — Activity feed missing AbortController.** `ActivityFeed` fetched transactions/milestones on mount and on `username` change but never cancelled in-flight requests. A stale response could resolve after unmount or after `username` changed and overwrite newer state. The fetch effect now creates an `AbortController`, passes its `signal` to both `fetch` calls, and aborts on cleanup. Abort errors are swallowed instead of surfacing as a load failure.
- **#647 — Create profile form allows double-submission.** Rapid clicks on the submit button in `create/page.tsx` could fire multiple `POST /profiles` requests before the first response arrived. `handleSubmit` now bails out immediately if a submission is already in flight, and the submit button shows an inline spinner while `loading` is true (in addition to the existing `disabled` state) so it's visually clear a submission is in progress.
- **#645 — Drip scheduler uses `setDate()` for month arithmetic.** `drip-scheduler.ts` advanced monthly drips with `nextRunAt.setDate(nextRunAt.getDate() + 30)`, which overflows at month boundaries (e.g. Jan 31 + 30 days lands on Mar 2, not Feb 28/29). Monthly drips now advance with proper calendar-month arithmetic (clamped to the last day of the target month when the day doesn't exist there), and weekly drips use explicit millisecond arithmetic. Added a regression test covering the Jan 31 → Feb 29 boundary case, and updated the existing monthly test to assert calendar-month advancement instead of the old 30-day behavior.
- **#644 — SupportPanel doesn't refresh wallet balance after a successful payment.** After a support transaction was signed and submitted to Horizon, the visitor's displayed XLM balance kept showing the pre-payment amount until a manual page refresh. `handleSend` now re-fetches the balance via the existing `loadBalance` helper immediately after `submitTransaction` resolves successfully.

## Why these are grouped

All four are small, low-risk, isolated bug fixes (one per file/concern) reported in the same triage pass. No schema, API contract, or dependency changes — kept as plain calendar-date arithmetic in the scheduler rather than adding `date-fns` as a new dependency, since it isn't currently installed in `backend/`.

## Test plan

- [ ] `ActivityFeed`: switch `username` quickly / unmount mid-fetch and confirm no console errors and no stale data flash; existing snapshot/partial-failure tests still pass.
- [ ] Create profile form: rapid-click "Create Profile →" and confirm only one `POST /profiles` request fires (network tab) and a spinner shows on the button.
- [ ] `drip-scheduler.test.ts`: existing weekly/monthly advancement tests pass with updated calendar-month assertion; new month-boundary regression test (Jan 31 → Feb 29) passes.
- [ ] `SupportPanel`: submit a support transaction on Testnet and confirm the displayed balance updates immediately after confirmation, without a manual page refresh.

Closes #648
Closes #647
Closes #645
Closes #644