### PR TITLE
Fix/rss sort contract docs edit auth error boundaries

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3334,8 +3334,20 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     </item>`;
     });
 
-    const allItems = [...txItems, ...milestoneItems]
-      .sort(() => 0)  // already ordered by recency from their respective queries
+    const allItemsWithTimestamp = [
+      ...txItems.map((item, idx) => ({ 
+        item, 
+        timestamp: transactions[idx].createdAt 
+      })),
+      ...milestoneItems.map((item, idx) => ({ 
+        item, 
+        timestamp: profile.milestones[idx].updatedAt 
+      }))
+    ];
+
+    const allItems = allItemsWithTimestamp
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      .map(entry => entry.item)
       .join("\n");
 
     const feed = `<?xml version="1.0" encoding="UTF-8"?>

--- a/contract/contracts/support_page/src/lib.rs
+++ b/contract/contracts/support_page/src/lib.rs
@@ -179,7 +179,7 @@ impl SupportPageContract {
             return Err(Error::InsufficientBalance);
         }
         
-        // Attempt transfer
+        // Transfer tokens - panics on failure per Soroban token contract spec
         client.transfer(&s, &e.current_contract_address(), &o);
 
         let st = e.storage().persistent();
@@ -279,7 +279,7 @@ impl SupportPageContract {
             return Err(Error::InsufficientContractBalance);
         }
 
-        // Transfer funds from contract to recipient
+        // Transfer funds from contract to recipient - panics on failure per Soroban token contract spec
         client.transfer(&e.current_contract_address(), &recipient, &amount);
 
         // Deduct from TotalByAsset storage

--- a/frontend/src/app/dashboard/[campaignId]/page.tsx
+++ b/frontend/src/app/dashboard/[campaignId]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { AppShell } from "@/components/app-shell";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { API_BASE_URL } from "@/lib/config";
 import { apiFetch } from "@/lib/api-client";
 import { stellarExpertUrl } from "@/lib/stellar";
@@ -580,11 +581,12 @@ export default function DashboardPage() {
   );
 
   return (
-    <AppShell>
-      <div className="mx-auto max-w-7xl space-y-8">
-        <Link href={`/profile/${campaignId}`} className="text-sm text-indigo-500 hover:underline">
-          ← Back to profile
-        </Link>
+    <ErrorBoundary>
+      <AppShell>
+        <div className="mx-auto max-w-7xl space-y-8">
+          <Link href={`/profile/${campaignId}`} className="text-sm text-indigo-500 hover:underline">
+            ← Back to profile
+          </Link>
         
         <header className="flex flex-col gap-2">
           <h1 className="text-3xl font-bold tracking-tight text-white">
@@ -1019,6 +1021,7 @@ export default function DashboardPage() {
         </section>
       </div>
     </AppShell>
+    </ErrorBoundary>
   );
 }
 

--- a/frontend/src/app/profile/[username]/edit/page.tsx
+++ b/frontend/src/app/profile/[username]/edit/page.tsx
@@ -61,6 +61,7 @@ export default function EditProfilePage() {
   const { toast, showToast, dismiss } = useToast();
 
   const [loading, setLoading] = useState(true);
+  const [ownershipChecked, setOwnershipChecked] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
@@ -82,7 +83,6 @@ export default function EditProfilePage() {
   useEffect(() => {
     async function init() {
       try {
-        // Fetch profile
         const res = await fetch(`${API_BASE_URL}/profiles/${username}`);
         if (!res.ok) {
           router.replace("/");
@@ -90,7 +90,6 @@ export default function EditProfilePage() {
         }
         const profile: ProfileData = await res.json();
 
-        // Check ownership via Freighter (not localStorage)
         const result = await getAddress().catch(() => ({ address: "", error: "Freighter not available" }));
         const connectedAddress = "address" in result ? result.address : "";
 
@@ -99,6 +98,7 @@ export default function EditProfilePage() {
           return;
         }
 
+        setOwnershipChecked(true);
         setForm({
           displayName: profile.displayName ?? "",
           bio: profile.bio ?? "",
@@ -199,7 +199,7 @@ export default function EditProfilePage() {
     }
   }
 
-  if (loading) {
+  if (loading || !ownershipChecked) {
     return (
       <AppShell>
         <div className="flex h-[60vh] items-center justify-center">

--- a/frontend/src/components/error-boundary.tsx
+++ b/frontend/src/components/error-boundary.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React from "react";
+import { AppShell } from "./app-shell";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error("Error boundary caught error:", error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <AppShell>
+          <div className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-4">
+            <div className="rounded-full bg-red-500/10 p-6">
+              <svg
+                className="h-16 w-16 text-red-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+            </div>
+            <div className="max-w-md text-center space-y-2">
+              <h2 className="text-2xl font-bold text-white">Something went wrong</h2>
+              <p className="text-steel">
+                An unexpected error occurred. Please try again or contact support if the problem persists.
+              </p>
+              {this.state.error && (
+                <details className="mt-4 rounded-xl border border-white/10 bg-white/5 p-4 text-left">
+                  <summary className="cursor-pointer text-sm font-semibold text-white">
+                    Error details
+                  </summary>
+                  <pre className="mt-2 overflow-auto text-xs text-red-400">
+                    {this.state.error.message}
+                  </pre>
+                </details>
+              )}
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={this.handleReset}
+                className="rounded-xl bg-mint px-6 py-3 text-sm font-bold text-ink hover:bg-mint/90 transition-colors"
+              >
+                Try again
+              </button>
+              <button
+                onClick={() => window.location.href = "/"}
+                className="rounded-xl border border-white/10 bg-white/5 px-6 py-3 text-sm font-semibold text-white hover:bg-white/10 transition-colors"
+              >
+                Go home
+              </button>
+            </div>
+          </div>
+        </AppShell>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary

## Closes #600 - RSS feed sort fixed
Fixed the no-op sort that was concatenating all transactions first, then all milestones. Now properly interleaves both by their respective timestamps in descending chronological order.

## Closes #599 - Contract token transfer documented
Added clarifying comments to the Soroban contract that token transfers panic on failure per the Soroban token contract specification. This is the expected behavior - when a transfer fails, the contract panics and reverts all state changes, preventing the scenario where storage is updated for a failed transfer.

## Closes #598 - Edit profile ownership check blocking
Added an ownershipChecked state flag that gates rendering until the Freighter ownership verification completes. This prevents the form from flashing before the redirect happens for unauthorized users.

## Closes #594 - Error boundary added
Created a reusable ErrorBoundary component and wrapped the dashboard page with it. The profile page already had an error.tsx file providing the same protection. Now both pages catch runtime errors and display a graceful fallback with retry options instead of white screen crashes.

