### PR TITLE
fix: concurrent badge skipping, analytics cache collision, period validation, RSS sort

### DIFF
--- a/backend/src/analytics.ts
+++ b/backend/src/analytics.ts
@@ -90,15 +90,15 @@ export async function getAnalytics(
   endDate?: Date,
   format?: "json" | "csv"
 ) {
-  const cacheKey = `${profileId}:${startDate?.getTime()}:${endDate?.getTime()}:${format}`;
+  const start = startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const end = endDate || new Date();
+
+  const cacheKey = `${profileId}:${start.toISOString()}:${end.toISOString()}:${format}`;
   const cached = analyticsCache.get(cacheKey);
 
   if (cached && isCacheValid(cached.timestamp)) {
     return cached.data;
   }
-
-  const start = startDate || new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
-  const end = endDate || new Date();
 
   const transactions = await prisma.supportTransaction.findMany({
     where: {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4281,6 +4281,11 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     const period = (req.query.period as string) || "daily";
     const assetCode = req.query.assetCode as string | undefined;
 
+    const VALID_PERIODS = ["daily", "weekly", "monthly"] as const;
+    if (!VALID_PERIODS.includes(period as any)) {
+      return res.status(400).json({ error: "period must be daily, weekly, or monthly" });
+    }
+
     const to = new Date(req.query.to as string || new Date().toISOString());
     const from = new Date(
       req.query.from as string ||

--- a/backend/src/services/badge-awarder.ts
+++ b/backend/src/services/badge-awarder.ts
@@ -11,18 +11,29 @@ function getBadgeNameByCriterion(criterion: string): string {
   return map[criterion] ?? "";
 }
 
-const pendingChecks = new Set<string>();
+function profileLockKey(profileId: string): bigint {
+  let h = 0n;
+  for (let i = 0; i < profileId.length; i++) {
+    h = (h * 31n + BigInt(profileId.charCodeAt(i))) & 0x7FFFFFFFFFFFFFFFn;
+  }
+  return h;
+}
 
 export async function checkAndAwardBadges(profileId: string): Promise<void> {
-  if (pendingChecks.has(profileId)) return;
-  pendingChecks.add(profileId);
+  const lockKey = profileLockKey(profileId);
 
-  setTimeout(async () => {
-    try {
-      const badges = await prisma.badge.findMany();
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Serialize concurrent badge checks for the same profile using a
+      // transaction-scoped advisory lock. Concurrent callers block until the
+      // current check commits, then each runs with the latest DB state rather
+      // than being silently dropped.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${lockKey})`;
+
+      const badges = await tx.badge.findMany();
       if (badges.length === 0) return;
 
-      const existingAwards = await prisma.profileBadge.findMany({
+      const existingAwards = await tx.profileBadge.findMany({
         where: { profileId },
         select: { badgeId: true },
       });
@@ -31,20 +42,20 @@ export async function checkAndAwardBadges(profileId: string): Promise<void> {
       if (awardedBadgeIds.size === badges.length) return;
 
       const [txCount, uniqueSupporters, totalsByAsset, milestonesReached] = await Promise.all([
-        prisma.supportTransaction.count({
+        tx.supportTransaction.count({
           where: { profileId, status: { not: "failed" } },
         }),
-        prisma.supportTransaction.findMany({
+        tx.supportTransaction.findMany({
           where: { profileId, supporterAddress: { not: null }, status: { not: "failed" } },
           distinct: ["supporterAddress"],
           select: { supporterAddress: true },
         }),
-        prisma.supportTransaction.groupBy({
+        tx.supportTransaction.groupBy({
           by: ["assetCode"],
           where: { profileId, status: { not: "failed" } },
           _sum: { amount: true },
         }),
-        prisma.milestone.count({
+        tx.milestone.count({
           where: { profileId, status: "reached" },
         }),
       ]);
@@ -75,7 +86,7 @@ export async function checkAndAwardBadges(profileId: string): Promise<void> {
 
         if (shouldAward) {
           try {
-            await prisma.profileBadge.create({
+            await tx.profileBadge.create({
               data: { profileId, badgeId: badge.id },
             });
             logger.info(
@@ -87,13 +98,11 @@ export async function checkAndAwardBadges(profileId: string): Promise<void> {
           }
         }
       }
-    } catch (err) {
-      logger.error(
-        { err, profileId },
-        "Error in checkAndAwardBadges",
-      );
-    } finally {
-      pendingChecks.delete(profileId);
-    }
-  }, 5000);
+    }, { timeout: 30000 });
+  } catch (err) {
+    logger.error(
+      { err, profileId },
+      "Error in checkAndAwardBadges",
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Fixes four backend bugs identified in issues #638, #639, #640, and #641.

### #640 — Concurrent support transactions can cause badge awarding to be skipped

**Root cause:** `checkAndAwardBadges` guarded concurrent runs with an in-memory `Set`. A second call arriving before the 5-second debounce fired was silently dropped and never re-evaluated, so any badge threshold crossed by that transaction could be permanently missed. In a multi-instance deployment every instance had its own independent `Set`, so the guard offered no protection at all.

**Fix:** Removed the `pendingChecks` Set and `setTimeout` debounce. The badge check now runs immediately inside a `prisma.$transaction` that acquires a `pg_advisory_xact_lock` keyed on a stable numeric hash of the `profileId`. Concurrent callers block until the current check commits, then each runs with the latest database state — no check is ever dropped.

### #641 — Analytics cache key collision when `startDate`/`endDate` are undefined

**Root cause:** The cache key was built as `` `${profileId}:${startDate?.getTime()}:${endDate?.getTime()}:${format}` `` before the defaults were applied. When either date was `undefined`, `?.getTime()` evaluated to `undefined`, producing keys like `"profileId:undefined:undefined:json"`. A no-filter call and an explicit-date call that happened to match the computed default range produced the same key, returning stale cached data.

**Fix:** Moved the `start`/`end` default computation above the cache key line and switched to `.toISOString()` so the key always reflects the actual query bounds.

### #638 — Analytics timeseries `period` parameter not validated

**Root cause:** The endpoint accepted any string for `period` and silently fell through to the daily branch for unrecognised values (e.g. `"hourly"`, `"abc"`), returning daily data with no error signal.

**Fix:** Added an explicit allowlist check immediately after reading `period`:
```ts
const VALID_PERIODS = ["daily", "weekly", "monthly"] as const;
if (!VALID_PERIODS.includes(period as any)) {
  return res.status(400).json({ error: "period must be daily, weekly, or monthly" });
}
```

### #639 — RSS feed items not sorted chronologically after merge

**Root cause:** The original code used `.sort(() => 0)` — a no-op comparator — so concatenated transaction and milestone items were never interleaved by date.

**Status:** The correct implementation (zip raw objects with their timestamps, sort descending by `createdAt`/`updatedAt`, then map to XML strings) is already present in the codebase. No further changes required; this PR closes the issue.

## Test plan

- [ ] Deploy to staging and verify badge awards are not missed when two support transactions arrive within the same second for the same profile
- [ ] Confirm that a `GET /v1/profiles/:username/analytics` call with no date params and one with explicit dates matching the 30-day default produce independent cache entries
- [ ] Confirm `GET /v1/profiles/:username/analytics/timeseries?period=hourly` returns `400` with the error message `"period must be daily, weekly, or monthly"`
- [ ] Confirm valid period values (`daily`, `weekly`, `monthly`) still return `200`
- [ ] Confirm RSS feed items appear in descending date order interleaving transactions and milestones

Closes #638
Closes #639
Closes #640
Closes #641