### PR TITLE
fix: resolve issues #630, #631, #632, #633

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2308,7 +2308,9 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
   const supportPayloadSchema = z.object({
     txHash: z.string().min(3),
-    amount: z.string().min(1),
+    amount: z.string()
+      .regex(/^\d+(\.\d{1,7})?$/, "amount must be a positive decimal with up to 7 decimal places")
+      .refine(v => parseFloat(v) > 0, "amount must be greater than zero"),
     assetCode: z.string().min(1),
     assetIssuer: z.string().optional().nullable(),
     status: z.string().default("pending"),
@@ -2821,39 +2823,46 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       return res.json(cached);
     }
 
-    const allGrouped = await prisma.supportTransaction.groupBy({
-      by: ["supporterAddress", "assetCode"],
-      where: {
-        profileId: profile.id,
-        status: { not: "failed" },
-        supporterAddress: { not: null },
-      },
-      _sum: { amount: true },
-      _count: { _all: true },
-    });
+    const orderClause =
+      sort === "transaction_count"
+        ? 'ORDER BY transaction_count DESC, total_amount DESC'
+        : 'ORDER BY total_amount DESC, transaction_count DESC';
 
-    const sorted = allGrouped.slice().sort((a: any, b: any) => {
-      if (sort === "transaction_count") {
-        const diff = (b._count._all ?? 0) - (a._count._all ?? 0);
-        return diff !== 0 ? diff : Number(b._sum.amount ?? 0) - Number(a._sum.amount ?? 0);
-      }
-      const diff = Number(b._sum.amount ?? 0) - Number(a._sum.amount ?? 0);
-      return diff !== 0 ? diff : (b._count._all ?? 0) - (a._count._all ?? 0);
-    });
+    const rows: any[] = await prisma.$queryRawUnsafe(
+      `SELECT "supporterAddress", "assetCode", SUM(amount) as total_amount, COUNT(*) as transaction_count
+       FROM "SupportTransaction"
+       WHERE "profileId" = $1 AND "status" != 'failed' AND "supporterAddress" IS NOT NULL
+       GROUP BY "supporterAddress", "assetCode"
+       ${orderClause}
+       LIMIT $2 OFFSET $3`,
+      profile.id,
+      limit,
+      offset
+    );
 
-    const paginated = sorted.slice(offset, offset + limit);
+    const totalResult: any[] = await prisma.$queryRawUnsafe(
+      `SELECT COUNT(*) as total FROM (
+         SELECT 1
+         FROM "SupportTransaction"
+         WHERE "profileId" = $1 AND "status" != 'failed' AND "supporterAddress" IS NOT NULL
+         GROUP BY "supporterAddress", "assetCode"
+       ) sub`,
+      profile.id
+    );
 
-    const leaderboard = paginated.map((entry: any, index: number) => ({
+    const total = Number(totalResult[0]?.total ?? 0);
+
+    const leaderboard = rows.map((entry: any, index: number) => ({
       rank: offset + index + 1,
       supporterAddress: entry.supporterAddress as string,
       assetCode: entry.assetCode,
-      totalAmount: entry._sum.amount?.toString() ?? "0",
-      transactionCount: entry._count._all ?? 0,
+      totalAmount: (entry.total_amount ?? "0").toString(),
+      transactionCount: Number(entry.transaction_count ?? 0),
     }));
 
     const payload = {
       leaderboard,
-      total: sorted.length,
+      total,
       limit,
       offset,
       sort,
@@ -4369,23 +4378,22 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     const profile = await prisma.profile.findUnique({ where: { username } });
     if (!profile) return sendError(res, 404, "Profile not found");
 
-    const transactions = await prisma.supportTransaction.findMany({
+    const rows = await prisma.supportTransaction.groupBy({
+      by: ["assetCode"],
       where: { profileId: profile.id, status: "SUCCESS" },
-      select: { assetCode: true, amount: true },
+      _sum: { amount: true },
     });
 
-    const assetMap = new Map<string, number>();
-    for (const tx of transactions) {
-      assetMap.set(tx.assetCode, (assetMap.get(tx.assetCode) ?? 0) + Number(tx.amount));
-    }
-
-    const total = Array.from(assetMap.values()).reduce((sum, v) => sum + v, 0);
-
-    const breakdown = Array.from(assetMap.entries()).map(([assetCode, amount]) => ({
-      assetCode,
-      amount: Number(amount.toFixed(7)),
-      percentage: total > 0 ? Number(((amount / total) * 100).toFixed(2)) : 0,
+    const breakdown = rows.map((row) => ({
+      assetCode: row.assetCode,
+      amount: Number(Number(row._sum.amount ?? 0).toFixed(7)),
+      percentage: 0,
     }));
+
+    const total = breakdown.reduce((sum, b) => sum + b.amount, 0);
+    for (const b of breakdown) {
+      b.percentage = total > 0 ? Number(((b.amount / total) * 100).toFixed(2)) : 0;
+    }
 
     return res.json({ breakdown, total: Number(total.toFixed(7)) });
   });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -101,9 +101,9 @@ export default function DashboardPage() {
         setUsername(storedUsername);
 
         const [statsRes, milestonesRes, webhooksRes] = await Promise.all([
-          fetch(`${API_BASE_URL}/profiles/${storedUsername}/stats`),
-          fetch(`${API_BASE_URL}/profiles/${storedUsername}/milestones`),
-          fetch(`${API_BASE_URL}/profiles/${storedUsername}/webhooks`),
+          apiFetch(`${API_BASE_URL}/profiles/${storedUsername}/stats`),
+          apiFetch(`${API_BASE_URL}/profiles/${storedUsername}/milestones`),
+          apiFetch(`${API_BASE_URL}/profiles/${storedUsername}/webhooks`),
         ]);
 
         if (statsRes.ok) {
@@ -141,7 +141,7 @@ export default function DashboardPage() {
         ? `${API_BASE_URL}/profiles/${username}/milestones/${editingMilestone.id}`
         : `${API_BASE_URL}/profiles/${username}/milestones`;
 
-      const res = await fetch(url, {
+      const res = await apiFetch(url, {
         method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -193,7 +193,7 @@ export default function DashboardPage() {
     if (!username) return;
 
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `${API_BASE_URL}/profiles/${username}/milestones/${milestoneId}`,
         { method: "DELETE" }
       );
@@ -225,7 +225,7 @@ export default function DashboardPage() {
 
     setWebhookSubmitting(true);
     try {
-      const res = await fetch(`${API_BASE_URL}/profiles/${username}/webhooks`, {
+      const res = await apiFetch(`${API_BASE_URL}/profiles/${username}/webhooks`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ url: webhookUrl }),
@@ -249,7 +249,7 @@ export default function DashboardPage() {
     if (!username) return;
 
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `${API_BASE_URL}/profiles/${username}/webhooks/${webhookId}`,
         { method: "DELETE" }
       );
@@ -273,7 +273,7 @@ export default function DashboardPage() {
     if (!deliveries[webhookId]) {
       setDeliveriesLoading(webhookId);
       try {
-        const res = await fetch(
+        const res = await apiFetch(
           `${API_BASE_URL}/profiles/${username}/webhooks/${webhookId}/deliveries`
         );
         if (res.ok) {


### PR DESCRIPTION
## Summary

Fixes four backend and frontend bugs.

### Changes

**Issue #630** - GET /profiles/:username/analytics/assets now uses Prisma `groupBy` instead of loading all transactions into memory, preventing OOM for profiles with 100k+ transactions.

**Issue #631** - Dashboard page now uses `apiFetch()` instead of bare `fetch()` for all API calls, ensuring 401 responses trigger the token refresh flow instead of silently failing.

**Issue #632** - Leaderboard endpoint now uses raw SQL with `ORDER BY`/`LIMIT`/`OFFSET` at the database level instead of fetching all grouped results and sorting/paginating in JavaScript, eliminating unbounded memory usage.

**Issue #633** - Support transaction `amount` field in `supportPayloadSchema` now validates with a regex (`/^\\d+(\\.\\d{1,7})?$/`) and a positive-value refinement, matching the recurring support schema's validation.

Closes #630
Closes #631
Closes #632
Closes #633