### PR TITLE
fix(email): add plain-text alt and unsubscribe link to weekly digest …

### DIFF
--- a/backend/src/services/weekly-digest.ts
+++ b/backend/src/services/weekly-digest.ts
@@ -90,6 +90,23 @@ export async function sendWeeklyDigests(prismaClient = prisma) {
             ? `<p><strong>Milestones reached:</strong> ${milestonesCount}</p>`
             : "";
 
+        const milestonesTextLine =
+          milestonesCount > 0
+            ? `\nMilestones reached this week: ${milestonesCount}`
+            : "";
+
+        const text =
+          `Your Weekly NovaSupport Recap\n\n` +
+          `Profile: ${profile.displayName}\n` +
+          `Total received: ${assetBreakdown}\n` +
+          `Transactions: ${txCount}\n` +
+          `New supporters: ${supporterCount}` +
+          milestonesTextLine +
+          `\n\nView your profile: https://novasupport.xyz/${profile.username}\n\n` +
+          `Thanks,\nThe NovaSupport Team\n\n` +
+          `To stop receiving these emails, update your notification preferences:\n` +
+          `https://novasupport.xyz/dashboard?settings=notifications`;
+
         const html = `
         <h2>Your Weekly NovaSupport Recap</h2>
         <p>Here's what happened with your profile <strong>${profile.displayName}</strong> this week:</p>
@@ -103,11 +120,17 @@ export async function sendWeeklyDigests(prismaClient = prisma) {
         <p><a href="https://novasupport.xyz/${profile.username}">View your profile</a></p>
         <br/>
         <p>Thanks,<br/>The NovaSupport Team</p>
+        <br/>
+        <p style="font-size:12px;color:#666">
+          <a href="https://novasupport.xyz/dashboard?settings=notifications">Unsubscribe</a>
+          from weekly emails
+        </p>
       `;
 
         await sendEmail({
           to: profile.email!,
           subject: "Your NovaSupport weekly recap",
+          text,
           html,
         });
 


### PR DESCRIPTION
#675 — Weekly digest: add plain-text alternative
weekly-digest.ts was sending HTML-only emails with no text/plain MIME part. Spam filters (SpamAssassin, Google Workspace, Microsoft 365) penalise single-part HTML emails and may route them to junk. Added a text field alongside html in the sendEmail call so Nodemailer sends a proper multipart/alternative message.

#676 — Weekly digest: add unsubscribe link (CAN-SPAM / GDPR)
The HTML email template had no unsubscribe mechanism. Under CAN-SPAM (US) and GDPR (EU), commercial emails must include a clear opt-out path. Added an unsubscribe footer to both the HTML and plain-text parts linking to /dashboard?settings=notifications.

#677 — Support notification emails: debounce burst transactions
app.ts was calling sendSupportReceivedEmail() on every single transaction with no rate limiting. During a livestream burst a creator could receive dozens of individual emails within minutes. Added a 15-minute cooldown per creator by checking and updating lastNotifiedAt on the NotificationPreferences row before sending.

#680 — resolveOrphans(): process orphans in batches
event-indexer.ts was loading all orphan transactions into memory on every 10-second poll tick with no take limit. On deployments with thousands of orphan rows this could cause OOM or timeouts. Changed to process orphans in batches of 200, looping until empty, so memory usage and resolution time per tick stay bounded.

Files changed
weekly-digest.ts
app.ts
event-indexer.ts
Testing
Existing unit tests pass unchanged.
SendEmailOptions in mailer.ts already had text?: string — no interface changes needed.
Closes #675
 Closes #676
  Closes #677 
  Closes #680