### PR TITLE
fix: batch orphan updates, add explore abort, and modal timeout feedb…

### DIFF
--- a/backend/src/services/event-indexer.ts
+++ b/backend/src/services/event-indexer.ts
@@ -235,15 +235,12 @@ export class EventIndexer {
     );
 
     let resolved = 0;
-    for (const orphan of orphans) {
-      const profileId = addressToProfileId.get(orphan.recipientAddress);
-      if (!profileId) continue;
-
-      await this.prisma.supportTransaction.update({
-        where: { id: orphan.id },
+    for (const [address, profileId] of addressToProfileId) {
+      const count = await this.prisma.supportTransaction.updateMany({
+        where: { profileId: "__orphan__", recipientAddress: address },
         data: { profileId },
       });
-      resolved += 1;
+      resolved += count.count;
     }
 
     if (resolved > 0) {

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { API_BASE_URL } from "@/lib/config";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
@@ -31,6 +31,7 @@ export default function ExplorePage() {
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const limit = 20;
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const sentinelRef = useInfiniteScroll({
     onLoadMore: handleLoadMore,
@@ -65,6 +66,10 @@ export default function ExplorePage() {
   }, [profiles]);
 
   async function fetchProfiles(currentOffset: number, reset = false) {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     try {
       setLoading(true);
       setError(null);
@@ -83,7 +88,9 @@ export default function ExplorePage() {
         params.append("assetIssuer", assetIssuer);
       }
 
-      const response = await fetch(`${API_BASE_URL}/profiles?${params}`);
+      const response = await fetch(`${API_BASE_URL}/profiles?${params}`, {
+        signal: controller.signal,
+      });
 
       if (!response.ok) {
         throw new Error("Failed to fetch profiles");
@@ -99,9 +106,12 @@ export default function ExplorePage() {
 
       setHasMore(data.profiles.length === limit);
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : "Failed to load profiles");
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
     }
   }
 

--- a/frontend/src/components/transaction-result-modal.tsx
+++ b/frontend/src/components/transaction-result-modal.tsx
@@ -105,6 +105,10 @@ export function TransactionResultModal({
     const interval = window.setInterval(() => {
       if (Date.now() - startedAt > maxDurationMs) {
         window.clearInterval(interval);
+        if (!pollingDoneRef.current) {
+          setTxStatus("failed");
+          setTxStatusMessage("Could not confirm in time. Check the explorer for status.");
+        }
         return;
       }
       if (pollingDoneRef.current) {


### PR DESCRIPTION
…ack (#678, #686, #687)

Closes #688 
Closes #686 
Closes #687 
Closes #678 
- event-indexer: replace per-row update loop with updateMany per address to eliminate N sequential DB roundtrips
- explore/page: add AbortController to cancel in-flight fetches when filter changes, preventing stale results being appended
- transaction-result-modal: set failed status with user message when 30s polling timeout elapses

## What does this PR do?

<!-- A clear 1-3 sentence summary of the change -->

## Related issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test

<!-- Step-by-step instructions for a reviewer to verify this works -->

1.
2.
3.

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [ ] My branch is up to date with main
- [ ] Linter passes (`npm run lint`)
- [ ] Tests pass (`npm test`) if applicable
- [ ] I have not committed `.env` files or secrets
