### PR TITLE
fix: use shared API_BASE_URL config and restore post-auth redirect

### DIFF
--- a/frontend/src/components/notification-preferences.tsx
+++ b/frontend/src/components/notification-preferences.tsx
@@ -3,8 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { Check } from "lucide-react";
 import { apiFetch } from "@/lib/api-client";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+import { API_BASE_URL } from "@/lib/config";
 
 type Prefs = {
   notifyOnSupport: boolean;

--- a/frontend/src/components/wallet-connect.tsx
+++ b/frontend/src/components/wallet-connect.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
 import {
   getAvailableWallets,
   getWalletAdapter,
@@ -20,6 +21,7 @@ type WalletConnectProps = {
 };
 
 export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
+  const router = useRouter();
   const [address, setAddress] = useState<string | null>(null);
   const [activeWallet, setActiveWallet] = useState<WalletId | null>(null);
   const [available, setAvailable] = useState<WalletAdapter[]>([]);
@@ -59,6 +61,12 @@ export function WalletConnect({ onConnect }: WalletConnectProps = {}) {
       setActiveWallet(walletId);
       setStatus(`${adapter.name} connected`);
       onConnect?.(pubkey);
+
+      const redirectPath = localStorage.getItem("redirectAfterLogin");
+      if (redirectPath) {
+        localStorage.removeItem("redirectAfterLogin");
+        router.replace(redirectPath);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : `Failed to connect ${adapter.name}.`;
       setError(msg);


### PR DESCRIPTION
## Summary

- **Issue #710** — `notification-preferences.tsx` was defining its own `API_BASE_URL` constant (`process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:4000'`) instead of importing the shared one from `@/lib/config`. Replaced the local constant with `import { API_BASE_URL } from '@/lib/config'` so the component always stays in sync with the rest of the app.

- **Issue #709** — `api-client.ts` saves the user's current path to `localStorage` (`redirectAfterLogin`) before redirecting on a 401, but nothing ever read that value back. Added logic in `wallet-connect.tsx` so that after a successful wallet connection, the app reads and clears `redirectAfterLogin` from localStorage and navigates to the saved path via `router.replace()`, returning users to where they were instead of dropping them on the homepage.

## Changes

- `frontend/src/components/notification-preferences.tsx` — remove duplicate `API_BASE_URL` constant, import from `@/lib/config`
- `frontend/src/components/wallet-connect.tsx` — add `useRouter`, redirect to `redirectAfterLogin` after successful connect

## Test plan

- [ ] Connect wallet after a 401 redirect — confirm browser navigates to the original page, not the homepage
- [ ] Connect wallet normally (no prior redirect) — confirm no unexpected navigation occurs
- [ ] Open notification preferences — confirm it correctly hits the API endpoint matching the rest of the app

Closes #709
Closes #710