### PR TITLE
Backend analytics fixes

### DIFF
--- a/backend/src/analytics.test.ts
+++ b/backend/src/analytics.test.ts
@@ -256,7 +256,7 @@ describe("Analytics Tests", () => {
         (a: any) => a.asset === "XLM",
       );
       assert.ok(xlmBreakdown);
-      assert.strictEqual(xlmBreakdown.amount, 500); // 100+50+200+150
+      assert.strictEqual(xlmBreakdown.amount, "500"); // 100+50+200+150
       assert.strictEqual(xlmBreakdown.count, 4);
     });
 

--- a/backend/src/analytics.ts
+++ b/backend/src/analytics.ts
@@ -97,46 +97,68 @@ export async function getAnalytics(
   const cached = analyticsCache.get(cacheKey);
 
   if (cached && isCacheValid(cached.timestamp)) {
-    return cached.data;
+    return format === "csv" ? convertToCSV(cached.data) : cached.data;
   }
 
-  const transactions = await prisma.supportTransaction.findMany({
-    where: {
-      profileId,
-      createdAt: { gte: start, lte: end },
-    },
-    orderBy: { createdAt: "asc" },
-  });
+  // Aggregate in the database rather than loading every row into memory.
+  // SUM is computed by Postgres on the Decimal column, preserving precision
+  // (no Number() conversion), and only one row per day is returned.
+  const [dailyRows, summaryAgg, contributorRows, assetGroups] =
+    await Promise.all([
+      prisma.$queryRaw<
+        {
+          date: string;
+          total: string | null;
+          txCount: number;
+          uniqueContributors: number;
+        }[]
+      >`
+        SELECT
+          to_char("createdAt", 'YYYY-MM-DD') AS date,
+          SUM("amount")::text AS total,
+          COUNT(*)::int AS "txCount",
+          COUNT(DISTINCT "supporterAddress")::int AS "uniqueContributors"
+        FROM "SupportTransaction"
+        WHERE "profileId" = ${profileId}
+          AND "createdAt" >= ${start}
+          AND "createdAt" <= ${end}
+        GROUP BY 1
+        ORDER BY 1 ASC
+      `,
+      prisma.supportTransaction.aggregate({
+        where: { profileId, createdAt: { gte: start, lte: end } },
+        _sum: { amount: true },
+        _count: true,
+      }),
+      prisma.$queryRaw<{ count: number }[]>`
+        SELECT COUNT(DISTINCT "supporterAddress")::int AS count
+        FROM "SupportTransaction"
+        WHERE "profileId" = ${profileId}
+          AND "createdAt" >= ${start}
+          AND "createdAt" <= ${end}
+      `,
+      prisma.supportTransaction.groupBy({
+        by: ["assetCode"],
+        where: { profileId, createdAt: { gte: start, lte: end } },
+        _sum: { amount: true },
+        _count: true,
+      }),
+    ]);
 
-  // Group by date
-  const groupedByDate = new Map<string, any[]>();
-  transactions.forEach((tx) => {
-    const date = tx.createdAt.toISOString().split("T")[0];
-    if (!groupedByDate.has(date)) {
-      groupedByDate.set(date, []);
-    }
-    groupedByDate.get(date)!.push(tx);
-  });
-
-  // Calculate metrics
-  const dailyData: DailyContribution[] = Array.from(
-    groupedByDate.entries()
-  ).map(([date, txs]) => {
-    const amount = txs
-      .reduce((sum, tx) => sum + Number(tx.amount), 0)
-      .toString();
-    const uniqueContributors = new Set(
-      txs.map((tx) => tx.supporterAddress)
-    ).size;
-    const avgContribution = (
-      Number(amount) / txs.length
-    ).toString();
-
+  // Per-day metrics, keeping amounts as decimal strings.
+  const dailyData: DailyContribution[] = dailyRows.map((row) => {
+    // Normalize Postgres numeric text (e.g. "150.0000000") to "150".
+    const amount =
+      row.total != null ? new Prisma.Decimal(row.total).toString() : "0";
+    const avgContribution =
+      row.txCount > 0
+        ? new Prisma.Decimal(amount).div(row.txCount).toString()
+        : "0";
     return {
-      date,
+      date: row.date,
       amount,
-      count: txs.length,
-      uniqueContributors,
+      count: row.txCount,
+      uniqueContributors: row.uniqueContributors,
       avgContribution,
     };
   });
@@ -164,19 +186,15 @@ export async function getAnalytics(
     currentDate.setDate(currentDate.getDate() + 1);
   }
 
-  // Calculate summary
-  const totalAmount = filledData
-    .reduce((sum, d) => sum + Number(d.amount), 0)
-    .toString();
-  const totalContributors = new Set(
-    transactions.map((tx) => tx.supporterAddress)
-  ).size;
-  const avgDailyContribution = (
-    filledData.length > 0
-      ? filledData.reduce((sum, d) => sum + Number(d.amount), 0) /
-        filledData.length
-      : 0
+  // Calculate summary using Decimal arithmetic to avoid precision loss.
+  const totalAmount = (
+    summaryAgg._sum.amount ?? new Prisma.Decimal(0)
   ).toString();
+  const totalContributors = contributorRows[0]?.count ?? 0;
+  const avgDailyContribution =
+    filledData.length > 0
+      ? new Prisma.Decimal(totalAmount).div(filledData.length).toString()
+      : "0";
 
   const result = {
     profileId,
@@ -184,27 +202,15 @@ export async function getAnalytics(
       totalRaised: totalAmount,
       totalContributors,
       avgDailyContribution,
-      transactionCount: transactions.length,
+      transactionCount: summaryAgg._count,
       dateRange: { start: start.toISOString(), end: end.toISOString() },
     },
     dailyContributions: filledData,
-    assetBreakdown: Object.values(
-      transactions.reduce(
-        (acc, tx) => {
-          if (!acc[tx.assetCode]) {
-            acc[tx.assetCode] = {
-              asset: tx.assetCode,
-              amount: 0,
-              count: 0,
-            };
-          }
-          acc[tx.assetCode].amount += Number(tx.amount);
-          acc[tx.assetCode].count += 1;
-          return acc;
-        },
-        {} as Record<string, any>
-      )
-    ),
+    assetBreakdown: assetGroups.map((group) => ({
+      asset: group.assetCode,
+      amount: (group._sum.amount ?? new Prisma.Decimal(0)).toString(),
+      count: group._count,
+    })),
   };
 
   analyticsCache.set(cacheKey, { data: result, timestamp: Date.now() });

--- a/backend/src/services/soroban-rpc-client.ts
+++ b/backend/src/services/soroban-rpc-client.ts
@@ -101,7 +101,12 @@ function decodeSupportEvent(event: RpcEvent): SupportEventRecord | null {
     pagingToken: event.pagingToken ?? event.id,
     amount: String(nativeObj.amount ?? "0"),
     assetCode: String(nativeObj.asset_code ?? nativeObj.assetCode ?? ""),
-    assetIssuer: null,
+    assetIssuer:
+      nativeObj.asset_issuer != null
+        ? String(nativeObj.asset_issuer)
+        : nativeObj.assetIssuer != null
+          ? String(nativeObj.assetIssuer)
+          : null,
     recipientAddress: asAddress(recipient),
     supporterAddress: asAddress(supporter),
     message: nativeObj.message == null ? null : String(nativeObj.message),


### PR DESCRIPTION
## What does this PR do?

#682 — unbounded findMany → DB aggregation. Replaced the findMany that loaded every transaction in the date range with four parallel aggregate queries (Promise.all):
- a $queryRaw that groups by UTC day (to_char("createdAt", 'YYYY-MM-DD')) returning per-day SUM, COUNT(*), and COUNT(DISTINCT supporterAddress) — one row per day instead of one row per transaction;
- aggregate for the overall sum and count;
- a $queryRaw for the distinct total contributors;
- groupBy(['assetCode']) for the asset breakdown.

#683 — floating-point precision loss. All sums are now computed by Postgres on the Decimal(18,7) column. Where division is needed (avgContribution, avgDailyContribution) it uses Prisma.Decimal.div(...) instead of Number(). Daily/total/asset amounts are emitted as normalized decimal strings (new Prisma.Decimal(...).toString()), so 0.1 + 0.2 style drift can't occur.

#684 — CSV cache returns [object Object]. The cache now always stores the JSON result object, and convertToCSV() is applied after the cache lookup on both the miss path and the hit path (return format === "csv" ? convertToCSV(cached.data) : cached.data), so a cached CSV request returns a real CSV string.

backend/src/services/soroban-rpc-client.ts

#685 — assetIssuer always null. Now reads the issuer from the event payload (asset_issuer / assetIssuer), mirroring the existing assetCode fallback pattern, falling back to null only when truly absent — so non-native tokens like USDC keep their issuer.

## Related issue

Closes #682 
Closes #683 
Closes #684 
Closes #685 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / config only

## How to test

<!-- Step-by-step instructions for a reviewer to verify this works -->

1.
2.
3.

## Checklist

- [ ] I have read the CONTRIBUTING guide
- [ ] My branch is up to date with main
- [ ] Linter passes (`npm run lint`)
- [ ] Tests pass (`npm test`) if applicable
- [ ] I have not committed `.env` files or secrets
