### PR TITLE
fix(frontend): remove invalid X-Frame-Options for embed route

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -18,7 +18,6 @@ const nextConfig = {
         source: "/embed/:path*",
         headers: [
           { key: "Access-Control-Allow-Origin", value: "*" },
-          { key: "X-Frame-Options", value: "ALLOWALL" },
           { key: "Content-Security-Policy", value: "frame-ancestors *" },
         ],
       },

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -319,7 +319,7 @@ export default async function ProfilePage({ params }: PageProps) {
                     className="flex items-center justify-between gap-4"
                   >
                     <span className="text-xs text-sky/70">#{entry.rank}</span>
-                    
+                    <a
                       href={stellarExpertUrl("account", entry.supporterAddress)}
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
What does this PR do?
Removes an invalid X-Frame-Options value (ALLOWALL) from the embed route headers in Next.js config.
The embed route already uses Content-Security-Policy frame-ancestors *, which is the correct standards-based policy for embedding.

Related issue
Closes #712

Type of change
 Bug fix
 New feature
 Refactor
 Docs / config only
How to test
Start the frontend app.
Open an embed URL such as /embed/{username}.
Inspect response headers for /embed/* and confirm X-Frame-Options is not present.
Confirm Content-Security-Policy includes frame-ancestors *.
Verify the page can still be embedded in an iframe from another origin.
Checklist
 I have read the CONTRIBUTING guide
 My branch is up to date with main
 Linter passes (npm run lint)
 Tests pass (npm test) if applicable
 I have not committed .env files or secrets
