### PR TITLE
fix(frontend): add clickjacking protection on non-embed routes

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -14,6 +14,14 @@ const nextConfig = {
   async headers() {
     return [
       {
+        // Deny framing on all non-embed routes to mitigate clickjacking
+        source: "/((?!embed).*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+        ],
+      },
+      {
         // Allow cross-origin embedding of the embed widget pages
         source: "/embed/:path*",
         headers: [

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -319,7 +319,7 @@ export default async function ProfilePage({ params }: PageProps) {
                     className="flex items-center justify-between gap-4"
                   >
                     <span className="text-xs text-sky/70">#{entry.rank}</span>
-                    
+                    <a
                       href={stellarExpertUrl("account", entry.supporterAddress)}
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
What does this PR do?
Adds clickjacking protection headers for all non-embed frontend routes by denying framing at both legacy and modern policy layers.

X-Frame-Options: DENY
Content-Security-Policy: frame-ancestors 'none'
The embed route remains separately configured for embed use cases.

Also includes a minimal pre-existing JSX parse fix in profile page so frontend lint/build checks can complete.

Related issue
Closes #713

Type of change
 Bug fix
 New feature
 Refactor
 Docs / config only
How to test
Start frontend app.
Request a non-embed page (example: /profile/{username}) and verify response headers include:
X-Frame-Options: DENY
Content-Security-Policy: frame-ancestors 'none'
Request an embed page (example: /embed/{username}) and verify embed route headers still apply.
Run frontend checks:
npm run lint
npm run build
Checklist
 I have read the CONTRIBUTING guide
 My branch is up to date with main
 Linter passes (npm run lint)
 Build passes (npm run build)
 I have not committed .env files or secrets