### PR TITLE
fix: SupportPanel form reset + Albedo wallet network compatibility

### DIFF
--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -82,6 +82,10 @@ export function SupportPanel({
   const [frequency, setFrequency] = useState<"weekly" | "monthly">("monthly");
   const [sending, setSending] = useState(false);
   const [txHash, setTxHash] = useState<string | null>(null);
+  // Values captured at submit time so the result modal can keep displaying them
+  // after the live form fields are cleared (#708).
+  const [submittedAmount, setSubmittedAmount] = useState("");
+  const [submittedMessage, setSubmittedMessage] = useState("");
   const { showToast } = useToast();
 
   const handleCopy = useCallback(async () => {
@@ -163,6 +167,13 @@ export function SupportPanel({
       ) as Transaction | FeeBumpTransaction;
       const result = await horizonServer.submitTransaction(tx);
       setTxHash(result.hash);
+      // Snapshot the submitted values so the result modal keeps showing them,
+      // then clear the form fields. This prevents the user from accidentally
+      // re-sending the same amount/message once the modal closes (#708).
+      setSubmittedAmount(amount);
+      setSubmittedMessage(message);
+      setAmount("");
+      setMessage("");
 
       if (isRecurring && profileId) {
         await apiFetch(`${API_BASE_URL}/api/v1/recurring-support`, {
@@ -664,10 +675,10 @@ export function SupportPanel({
 
       <TransactionResultModal
         txHash={txHash}
-        amount={amount}
+        amount={submittedAmount}
         assetCode={paymentAsset.code || "XLM"}
         recipientDisplayName={recipientDisplayName}
-        note={message || null}
+        note={submittedMessage || null}
         isOpen={txHash !== null}
         onClose={() => setTxHash(null)}
       />

--- a/frontend/src/lib/wallet-adapters.ts
+++ b/frontend/src/lib/wallet-adapters.ts
@@ -3,6 +3,8 @@
  * Provides a consistent interface across Freighter, Albedo, and Lobstr.
  */
 
+import { Networks } from "@stellar/stellar-sdk";
+
 export type WalletId = "freighter" | "albedo" | "lobstr";
 
 export type WalletErrorCode =
@@ -113,7 +115,11 @@ const albedoAdapter: WalletAdapter = {
   async signTransaction(xdr, { networkPassphrase }) {
     const albedo = (window as any).albedo;
     if (!albedo) throw new WalletError("Albedo extension not found.", "NOT_FOUND");
-    const result = await albedo.tx({ xdr, network: networkPassphrase });
+    // Albedo's tx() expects the shorthand "public" | "testnet", not the full
+    // network passphrase. Passing the passphrase makes every sign fail (#707).
+    const network =
+      networkPassphrase === Networks.PUBLIC ? "public" : "testnet";
+    const result = await albedo.tx({ xdr, network });
     if (!result?.signed_envelope_xdr)
       throw new WalletError("Albedo did not return a signed transaction.", "SIGNING_FAILED");
     return result.signed_envelope_xdr;


### PR DESCRIPTION
## Summary

Fixes two frontend bugs in the support flow.

### #708 — SupportPanel does not clear amount and message after a successful transaction
After a successful payment, the `amount` and `message` fields stayed populated, making it easy to accidentally re-send the same support (especially on mobile).

- The success values are snapshotted into `submittedAmount` / `submittedMessage` before clearing the live inputs.
- The `TransactionResultModal` now reads those snapshots, so it still shows the correct amount and note while open — clearing the live fields immediately would otherwise blank out the modal (it renders the props live).
- After a successful submit, the form is cleared.

### #707 — Albedo wallet adapter passed the full network passphrase
`albedo.tx()` expects the shorthand `"public"` | `"testnet"`, but the full passphrase (e.g. `"Test SDF Network ; September 2015"`) was being passed, so every Albedo sign attempt failed.

- The short network name is now derived from the passphrase via `Networks.PUBLIC` from `@stellar/stellar-sdk`.

## Testing
- `npx tsc --noEmit` — no new type errors in the changed files.
- `npx next lint` on both changed files — no warnings or errors.
- The pre-existing support-panel test pass/fail count is unchanged (failures are environmental and present on `main` before this change).

## Notes
- Changes are minimal and follow existing code style/patterns.
- Freighter and Lobstr adapters are untouched and continue to work.

Closes #707
Closes #708