### PR TITLE
fix: cap analytics in-memory cache at 1000 entries to prevent OOM

### DIFF
--- a/backend/src/analytics.ts
+++ b/backend/src/analytics.ts
@@ -6,6 +6,7 @@ const analyticsCache = new Map<
   { data: any; timestamp: number }
 >();
 const CACHE_TTL = 3600000; // 1 hour
+const CACHE_MAX_SIZE = 1000;
 
 interface DailyContribution {
   date: string;
@@ -214,6 +215,12 @@ export async function getAnalytics(
   };
 
   analyticsCache.set(cacheKey, { data: result, timestamp: Date.now() });
+
+  // Evict oldest entries when the cache exceeds max size to prevent OOM
+  if (analyticsCache.size > CACHE_MAX_SIZE) {
+    const oldest = analyticsCache.keys().next().value;
+    if (oldest !== undefined) analyticsCache.delete(oldest);
+  }
 
   if (format === "csv") {
     return convertToCSV(result);


### PR DESCRIPTION
The analytics in-memory cache was unbounded — every unique (profileId, startDate, endDate) combo inserted a permanent entry, risking OOM under load or targeted abuse.


- backend/src/analytics.ts — added `CACHE_MAX_SIZE = 1000` constant. After each `set()`, if the cache exceeds the limit the oldest inserted entry (first key in Map insertion order) is evicted, keeping memory use bounded.

Closes #674