### PR TITLE
fix: rename SupportTx.senderAddress to supporterAddress to match API …

### DIFF
--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -38,7 +38,7 @@ type SupportTx = {
   assetCode: string;
   message?: string | null;
   createdAt: string;
-  senderAddress: string;
+  supporterAddress: string | null;
 };
 
 type Milestone = {


### PR DESCRIPTION
The `SupportTx` type in the profile page used `senderAddress` but the backend API returns `supporterAddress`. Any code reading `tx.senderAddress` got `undefined` at runtime with no TypeScript error.


- `frontend/src/app/profile/[username]/page.tsx` — renamed `senderAddress: string` to `supporterAddress: string | null` in the `SupportTx` type to match the actual API response shape.

Closes #681