### PR TITLE
fix: sync accepted assets and fix activity feed issues #740 #741 #742 #743

### DIFF
--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -430,6 +430,12 @@ export default function CreatePage() {
                         key={asset}
                         type="button"
                         onClick={() => {
+                          const isSelected = assets.some((a) => a.code === asset);
+                          setAssets(
+                            isSelected
+                              ? assets.filter((a) => a.code !== asset)
+                              : [...assets, { code: asset, issuer: "" }]
+                          );
                           setForm((prev) => ({
                             ...prev,
                             acceptedAssets: prev.acceptedAssets.includes(asset)
@@ -438,7 +444,7 @@ export default function CreatePage() {
                           }));
                         }}
                         className={`rounded-xl border px-4 py-2 text-xs font-semibold transition ${
-                          form.acceptedAssets.includes(asset)
+                          assets.some((a) => a.code === asset)
                             ? "border-mint bg-mint/10 text-mint"
                             : "border-white/10 bg-white/5 text-steel hover:border-white/20"
                         }`}

--- a/frontend/src/components/activity-feed.tsx
+++ b/frontend/src/components/activity-feed.tsx
@@ -12,8 +12,8 @@ import {
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+import { API_BASE_URL } from "@/lib/config";
+import { stellarExpertUrl } from "@/lib/stellar";
 
 type ActivityItem = {
   id: string;
@@ -120,13 +120,13 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
           id: `tx-${tx.id}`,
           type: "support",
           title: `Received ${tx.amount} ${tx.assetCode}`,
-          description: `Support from ${truncateHash(tx.senderAddress, 8)}`,
+          description: `Support from ${truncateHash(tx.supporterAddress ?? '', 8)}`,
           timestamp: tx.createdAt,
           icon: getActivityIcon("support"),
           metadata: {
             amount: tx.amount,
             assetCode: tx.assetCode,
-            supporter: tx.senderAddress,
+            supporter: tx.supporterAddress,
             txHash: tx.txHash,
           },
         });
@@ -257,7 +257,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
                         )}
                         {activity.metadata.txHash && (
                           <Link
-                            href={`https://stellar.expert/explorer/${process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'MAINNET' ? 'mainnet' : 'testnet'}/tx/${activity.metadata.txHash}`}
+                            href={stellarExpertUrl('tx', activity.metadata.txHash)}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="inline-flex items-center gap-1 px-2 py-1 rounded bg-white/5 text-xs text-white/70 hover:text-white/90 transition font-mono"


### PR DESCRIPTION
## Summary

Fixes four frontend issues affecting profile creation and activity feed display:

- **#740**: Accepted asset quickpick toggles now sync to the correct state variable (`setAssets`), ensuring the profile is created with user-selected assets instead of always defaulting to XLM.
- **#741**: Activity feed now reads `tx.supporterAddress` (correct field) instead of `tx.senderAddress`, properly displaying supporter identifiers.
- **#742**: Stellar Expert URLs now use the `stellarExpertUrl()` helper and correct network check (PUBLIC vs MAINNET) instead of hardcoding the URL.
- **#743**: Removed local `API_BASE_URL` constant and imported from `@/lib/config` to prevent config drift.

## Test plan

- [ ] Create a new profile and select multiple assets (USDC, AQUA) — verify the API receives all selected assets, not just XLM
- [ ] View activity feed with transactions — verify supporter addresses display correctly instead of undefined
- [ ] Click Stellar Expert links in activity feed — verify they route to the correct network (mainnet or testnet based on env)
- [ ] Verify no console errors related to API_BASE_URL or missing imports

## Closes

- Closes #740
- Closes #741
- Closes #742
- Closes #743