### PR TITLE
fix: tighten username regex, align sanitizer limits, fix Soroban fall…

### DIFF
--- a/backend/src/middleware/sanitize.ts
+++ b/backend/src/middleware/sanitize.ts
@@ -64,12 +64,12 @@ const LOWERCASE_FIELDS = new Set([
 
 // Maximum lengths for different field types
 const MAX_LENGTHS = {
-  bio: 500,
+  bio: 280,
   message: 280,
   description: 1000,
-  displayName: 100,
+  displayName: 64,
   title: 200,
-  username: 50,
+  username: 32,
   twitterHandle: 15,
   githubHandle: 39,
   url: 2048,

--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -92,8 +92,8 @@ export default function CreatePage() {
   const rateLimited = rateLimitRemainingMinutes > 0;
   const usernameFieldError =
     fieldErrors.username ??
-    (form.username && !/^[a-zA-Z0-9\-]+$/.test(form.username)
-      ? "Username can only contain alphanumeric characters and hyphens."
+    (form.username && !/^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?$/.test(form.username)
+      ? "Username can only contain alphanumeric characters and hyphens, and must start and end with an alphanumeric character."
       : null);
 
   function set(field: keyof FormData) {
@@ -137,8 +137,8 @@ export default function CreatePage() {
         setError("Display name and username are required.");
         return;
       }
-      if (!/^[a-zA-Z0-9\-]+$/.test(form.username)) {
-        setError("Username can only contain alphanumeric characters and hyphens.");
+      if (!/^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?$/.test(form.username)) {
+        setError("Username can only contain alphanumeric characters and hyphens, and must start and end with an alphanumeric character.");
         return;
       }
     }


### PR DESCRIPTION

Fixes four frontend and backend correctness issues:

#744 — create/page.tsx username regex accepted leading/trailing hyphens, producing broken profile URLs like /profile/-name-. Both the inline error check (line 95) and the step-advance guard (line 140) now use /^[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?$/ so usernames must start and end with an alphanumeric character.

#745 — sanitize.ts MAX_LENGTHS allowed bio up to 500, displayName up to 100, and username up to 50, all larger than the actual business limits enforced by the frontend and Zod schemas. Aligned the sanitizer caps to the real constraints: bio → 280, displayName → 64, username → 32. Direct API calls can no longer store overlong values that render broken in UI components.

#748 — stellar.ts buildSupportIntent silently caught Soroban contract build errors and fell through to a plain Horizon payment. Because the backend event indexer only watches Soroban contract events, those plain payments were never recorded: the creator never saw them, webhooks never fired, and milestone progress was never updated. The catch block now surfaces the error to the caller instead of falling back transparently.

#749 — support-panel.tsx sliced the memo at 28 characters, but Stellar's Memo.text() enforces a 28-byte limit. Multi-byte characters (emoji, CJK) overflow the byte budget well before the character count reaches 28, causing Memo.text() to throw and aborting the transaction with a generic error. The input now measures byte length via TextEncoder and rejects input that would exceed 28 bytes, with a user-facing message explaining the constraint.

Closes #744
Closes #745
Closes #748
Closes #749

