### PR TITLE
fix: add vitest to CI, guard milestone NaN, block SSRF vectors, enfor…

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -33,6 +33,7 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+      - run: npm test
       - run: npm run lint
       - run: npm run build
 

--- a/frontend/src/components/milestone-card.tsx
+++ b/frontend/src/components/milestone-card.tsx
@@ -81,7 +81,7 @@ function ConfettiBurst() {
 export function MilestoneCard({ milestone, index = 0 }: MilestoneCardProps) {
   const current = parseFloat(milestone.currentAmount);
   const target = parseFloat(milestone.targetAmount);
-  const progress = Math.min((current / target) * 100, 100);
+  const progress = target > 0 ? Math.min((current / target) * 100, 100) : 0;
   const isReached = milestone.status === "reached" || progress >= 100;
 
   return (


### PR DESCRIPTION


#751 — frontend.yml was running lint and build but silently skipping all vitest unit tests on every PR. Added `npm test` step after `npm ci` so test failures now break the CI job.

#750 — MilestoneCard divided by zero when targetAmount is 0, producing NaN% in the progress label and a broken progress bar. Guarded the calculation so target === 0 yields 0% instead of NaN.

#747 — sanitize.ts webhook SSRF check missed 169.254.x.x (AWS/GCP/Azure instance-metadata), IPv6 localhost (::1), ULA ranges (fd00::/8), and IPv4-mapped loopback (::ffff:127.x). Added all missing hostname checks to the existing block list alongside 0.0.0.0.

#746 — sanitize.ts normalizeUrl accepted plain http:// URLs with no violation, letting a direct API PATCH bypass the HTTPS requirement enforced only in the edit-profile UI. Added an explicit violation and early return for http: protocol so non-HTTPS URLs are rejected at the sanitization layer.

Closes #751
Closes #750
Closes #747
Closes #746
