### PR TITLE
Fix #762, #765, #766, #768: CSP header, recurring page, settings page, onboarding checklist

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4124,7 +4124,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     // Supporter view — return the authenticated user's own drip subscriptions
     const subscriptions = await prisma.recurringSupport.findMany({
       where: { supporterId: user.id, status: { not: "cancelled" } },
-      include: { profile: { select: { username: true, displayName: true } } },
+      include: { profile: { select: { username: true, displayName: true, avatarUrl: true } } },
       orderBy: { createdAt: "desc" },
     });
 
@@ -4133,6 +4133,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       profileId: s.profileId,
       profileUsername: s.profile.username,
       profileDisplayName: s.profile.displayName,
+      profileAvatarUrl: s.profile.avatarUrl,
       amount: s.amount.toString(),
       assetCode: s.assetCode,
       frequency: s.frequency,

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -18,7 +18,17 @@ const nextConfig = {
         source: "/((?!embed).*)",
         headers: [
           { key: "X-Frame-Options", value: "DENY" },
-          { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline'", // 'unsafe-inline' needed for Next.js inline chunks
+              "style-src 'self' 'unsafe-inline'",
+              `connect-src 'self' ${process.env.NEXT_PUBLIC_API_BASE_URL ?? ""} ${process.env.NEXT_PUBLIC_HORIZON_URL ?? ""} ${process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? ""}`,
+              "img-src 'self' data: blob: https:",
+              "frame-ancestors 'none'",
+            ].join("; "),
+          },
         ],
       },
       {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { AppShell } from "@/components/app-shell";
 import { Toast } from "@/components/toast";
+import { OnboardingChecklist } from "@/components/onboarding-checklist";
 import { 
   TrendingUp, Users, Wallet, Activity, 
   ArrowUpRight, ArrowDownRight, Plus, Edit2, Trash2, X, Link2, Eye, EyeOff, Copy, Check, ChevronDown, ChevronRight, Download
@@ -392,6 +393,10 @@ export default function DashboardPage() {
             )}
           </div>
         </header>
+
+        {username && (
+          <OnboardingChecklist username={username} milestoneCount={milestones.length} />
+        )}
 
         {/* Summary Cards */}
         {stats && (

--- a/frontend/src/app/recurring/page.tsx
+++ b/frontend/src/app/recurring/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AppShell } from "@/components/app-shell";
+import { Toast } from "@/components/toast";
+import { EmptyState } from "@/components/empty-state";
+import { apiFetch } from "@/lib/api-client";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+
+interface RecurringSupport {
+  id: string;
+  profileId: string;
+  profileUsername: string;
+  profileDisplayName: string;
+  profileAvatarUrl: string | null;
+  amount: string;
+  assetCode: string;
+  frequency: string;
+  nextRunAt: string;
+  status: string;
+  createdAt: string;
+}
+
+export default function RecurringPage() {
+  const router = useRouter();
+  const [subscriptions, setSubscriptions] = useState<RecurringSupport[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState<string | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+
+  useEffect(() => {
+    const username = localStorage.getItem("username");
+    if (!username) {
+      router.push("/");
+      return;
+    }
+
+    apiFetch(`${API_BASE_URL}/v1/recurring-support`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error("Failed to load recurring support subscriptions");
+        const data = await res.json();
+        setSubscriptions(data);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Something went wrong");
+      })
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  async function handleCancel(id: string) {
+    setCancelling(id);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/v1/recurring-support/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to cancel subscription");
+      setSubscriptions((prev) => prev.filter((s) => s.id !== id));
+      setToast({ message: "Subscription cancelled", type: "success" });
+    } catch (err: unknown) {
+      setToast({
+        message: err instanceof Error ? err.message : "Failed to cancel subscription",
+        type: "error",
+      });
+    } finally {
+      setCancelling(null);
+      setCancelTarget(null);
+    }
+  }
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-3xl px-4 py-10">
+        <h1 className="text-2xl font-semibold text-white mb-1">Recurring support</h1>
+        <p className="text-sm text-white/50 mb-8">
+          Manage the creators you support on a recurring basis.
+        </p>
+
+        {loading && <p className="text-sm text-white/40">Loading…</p>}
+        {error && <p className="text-sm text-red-400">{error}</p>}
+
+        {!loading && !error && subscriptions.length === 0 && (
+          <EmptyState
+            title="No recurring support yet"
+            description="When you set up a recurring drip to a creator, it will show up here."
+          />
+        )}
+
+        {!loading && subscriptions.length > 0 && (
+          <ul className="space-y-3">
+            {subscriptions.map((sub) => (
+              <li
+                key={sub.id}
+                className="flex items-center justify-between gap-4 rounded-2xl border border-white/10 bg-white/5 p-4"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  {sub.profileAvatarUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element -- arbitrary external avatar URLs, matches profile-card.tsx convention
+                    <img
+                      src={sub.profileAvatarUrl}
+                      alt={sub.profileDisplayName}
+                      className="h-10 w-10 rounded-full object-cover flex-shrink-0"
+                    />
+                  ) : (
+                    <div className="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center text-sm text-white/60 flex-shrink-0">
+                      {sub.profileDisplayName?.[0]?.toUpperCase() ?? "?"}
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-white truncate">
+                      {sub.profileDisplayName}
+                    </p>
+                    <p className="text-xs text-white/40">
+                      {sub.amount} {sub.assetCode} · {sub.frequency} · next{" "}
+                      {new Date(sub.nextRunAt).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+
+                {cancelTarget === sub.id ? (
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <span className="text-xs text-white/50">Cancel?</span>
+                    <button
+                      onClick={() => handleCancel(sub.id)}
+                      disabled={cancelling === sub.id}
+                      className="rounded-lg bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/30"
+                    >
+                      {cancelling === sub.id ? "Cancelling…" : "Yes, cancel"}
+                    </button>
+                    <button
+                      onClick={() => setCancelTarget(null)}
+                      className="rounded-lg px-3 py-1.5 text-xs text-white/50 hover:text-white"
+                    >
+                      Keep it
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    onClick={() => setCancelTarget(sub.id)}
+                    className="flex-shrink-0 rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-white/70 hover:border-red-400/40 hover:text-red-300"
+                  >
+                    Cancel
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {toast && <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />}
+    </AppShell>
+  );
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AppShell } from "@/components/app-shell";
+import { Toast } from "@/components/toast";
+import { NotificationPreferences } from "@/components/notification-preferences";
+import { apiFetch } from "@/lib/api-client";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState<string | null>(null);
+  const [emailVerified, setEmailVerified] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [resending, setResending] = useState(false);
+  const [deleteStep, setDeleteStep] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" } | null>(null);
+
+  useEffect(() => {
+    const storedUsername = localStorage.getItem("username");
+    if (!storedUsername) {
+      router.push("/");
+      return;
+    }
+    setUsername(storedUsername);
+
+    apiFetch(`${API_BASE_URL}/profiles/${storedUsername}`)
+      .then(async (res) => {
+        if (!res.ok) return;
+        const data = await res.json();
+        setEmailVerified(Boolean(data.emailVerified));
+      })
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  async function handleResendVerification() {
+    if (!username) return;
+    setResending(true);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/profiles/${username}/resend-verification-email`, {
+        method: "POST",
+      });
+      setToast(
+        res.ok
+          ? { message: "Verification email sent — check your inbox", type: "success" }
+          : { message: "Failed to resend verification email", type: "error" },
+      );
+    } catch {
+      setToast({ message: "Failed to resend verification email", type: "error" });
+    } finally {
+      setResending(false);
+    }
+  }
+
+  async function handleDeleteProfile() {
+    if (!username) return;
+    setDeleting(true);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/profiles/${username}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete profile");
+      localStorage.removeItem("username");
+      router.push("/");
+    } catch (err: unknown) {
+      setToast({
+        message: err instanceof Error ? err.message : "Failed to delete profile",
+        type: "error",
+      });
+      setDeleting(false);
+      setDeleteStep(0);
+    }
+  }
+
+  if (loading || !username) {
+    return (
+      <AppShell>
+        <div className="mx-auto max-w-2xl px-4 py-10">
+          <p className="text-sm text-white/40">Loading…</p>
+        </div>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-2xl px-4 py-10 space-y-8">
+        <div>
+          <h1 className="text-2xl font-semibold text-white mb-1">Settings</h1>
+          <p className="text-sm text-white/50">Manage your account preferences.</p>
+        </div>
+
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-6 space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-white/60">
+            Email verification
+          </h2>
+          <div className="flex items-center justify-between">
+            <span
+              className={`text-sm ${emailVerified ? "text-mint" : "text-amber-400"}`}
+            >
+              {emailVerified ? "Verified" : "Not verified"}
+            </span>
+            {!emailVerified && (
+              <button
+                onClick={handleResendVerification}
+                disabled={resending}
+                className="rounded-lg border border-white/10 px-3 py-1.5 text-xs font-medium text-white/70 hover:border-mint/40 hover:text-mint"
+              >
+                {resending ? "Sending…" : "Resend verification email"}
+              </button>
+            )}
+          </div>
+        </section>
+
+        <NotificationPreferences username={username} />
+
+        <section className="rounded-2xl border border-red-500/20 bg-red-500/5 p-6 space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-widest text-red-300">
+            Danger zone
+          </h2>
+          <p className="text-xs text-white/50">
+            Deleting your profile permanently removes it and all related data (transactions,
+            milestones, webhooks). This cannot be undone.
+          </p>
+
+          {deleteStep === 0 && (
+            <button
+              onClick={() => setDeleteStep(1)}
+              className="rounded-lg border border-red-500/30 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/10"
+            >
+              Delete profile
+            </button>
+          )}
+
+          {deleteStep === 1 && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-white/60">Are you sure?</span>
+              <button
+                onClick={() => setDeleteStep(2)}
+                className="rounded-lg bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/30"
+              >
+                Yes, continue
+              </button>
+              <button
+                onClick={() => setDeleteStep(0)}
+                className="rounded-lg px-3 py-1.5 text-xs text-white/50 hover:text-white"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {deleteStep === 2 && (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-white/60">
+                This is permanent. Delete @{username}?
+              </span>
+              <button
+                onClick={handleDeleteProfile}
+                disabled={deleting}
+                className="rounded-lg bg-red-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-600"
+              >
+                {deleting ? "Deleting…" : "Permanently delete"}
+              </button>
+              <button
+                onClick={() => setDeleteStep(0)}
+                className="rounded-lg px-3 py-1.5 text-xs text-white/50 hover:text-white"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </section>
+      </div>
+
+      {toast && <Toast message={toast.message} type={toast.type} onDismiss={() => setToast(null)} />}
+    </AppShell>
+  );
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -129,6 +129,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 <Link href="/create" className="hover:text-white transition">
                   Create draft
                 </Link>
+                <Link href="/recurring" className="hover:text-white transition">
+                  Recurring support
+                </Link>
+                <Link href="/settings" className="hover:text-white transition">
+                  Settings
+                </Link>
               </nav>
               <ThemeToggle />
             </div>

--- a/frontend/src/components/onboarding-checklist.tsx
+++ b/frontend/src/components/onboarding-checklist.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Check } from "lucide-react";
+import { apiFetch } from "@/lib/api-client";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+const DISMISSED_KEY_PREFIX = "onboardingChecklistDismissed:";
+
+type ChecklistItem = {
+  key: string;
+  label: string;
+  done: boolean;
+  href: string;
+};
+
+type Props = {
+  username: string;
+  milestoneCount: number;
+};
+
+export function OnboardingChecklist({ username, milestoneCount }: Props) {
+  const [dismissed, setDismissed] = useState(true); // default hidden until we know state
+  const [profile, setProfile] = useState<{
+    emailVerified: boolean;
+    avatarUrl: string | null;
+    bio: string;
+    websiteUrl: string | null;
+    twitterHandle: string | null;
+    githubHandle: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    const dismissedKey = `${DISMISSED_KEY_PREFIX}${username}`;
+    if (localStorage.getItem(dismissedKey) === "true") {
+      return; // stay dismissed, don't bother fetching
+    }
+
+    apiFetch(`${API_BASE_URL}/profiles/${username}`)
+      .then(async (res) => {
+        if (!res.ok) return;
+        const data = await res.json();
+        setProfile({
+          emailVerified: Boolean(data.emailVerified),
+          avatarUrl: data.avatarUrl ?? null,
+          bio: data.bio ?? "",
+          websiteUrl: data.websiteUrl ?? null,
+          twitterHandle: data.twitterHandle ?? null,
+          githubHandle: data.githubHandle ?? null,
+        });
+        setDismissed(false);
+      })
+      .catch(() => {});
+  }, [username]);
+
+  if (dismissed || !profile) return null;
+
+  const items: ChecklistItem[] = [
+    {
+      key: "email",
+      label: "Verify your email",
+      done: profile.emailVerified,
+      href: "/settings",
+    },
+    {
+      key: "avatar",
+      label: "Add an avatar",
+      done: !!profile.avatarUrl,
+      href: `/profile/${username}/edit`,
+    },
+    {
+      key: "bio",
+      label: "Write a bio",
+      done: profile.bio.trim().length > 0,
+      href: `/profile/${username}/edit`,
+    },
+    {
+      key: "social",
+      label: "Connect a social link",
+      done: !!(profile.websiteUrl || profile.twitterHandle || profile.githubHandle),
+      href: `/profile/${username}/edit`,
+    },
+    {
+      key: "milestone",
+      label: "Create your first milestone",
+      done: milestoneCount > 0,
+      href: "/dashboard",
+    },
+    {
+      key: "share",
+      label: "Share your page",
+      done: false, // no on-chain/off-chain signal for this yet — always actionable
+      href: `/profile/${username}`,
+    },
+  ];
+
+  const completedCount = items.filter((i) => i.done).length;
+  const allComplete = completedCount === items.length;
+
+  function handleDismiss() {
+    localStorage.setItem(`${DISMISSED_KEY_PREFIX}${username}`, "true");
+    setDismissed(true);
+  }
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-widest text-white/60">
+          Getting started
+        </h2>
+        <button
+          onClick={handleDismiss}
+          className="text-xs text-white/40 hover:text-white"
+        >
+          {allComplete ? "Dismiss" : "Got it"}
+        </button>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between text-xs text-white/50 mb-1">
+          <span>
+            {completedCount} of {items.length} steps complete
+          </span>
+        </div>
+        <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-[#00e5b0] transition-all"
+            style={{ width: `${(completedCount / items.length) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.key}>
+            <Link
+              href={item.href}
+              className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition ${
+                item.done
+                  ? "text-white/40"
+                  : "text-white hover:bg-white/[0.04]"
+              }`}
+            >
+              <span
+                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full border ${
+                  item.done ? "border-mint bg-mint/20 text-mint" : "border-white/20"
+                }`}
+              >
+                {item.done && <Check size={10} />}
+              </span>
+              <span className={item.done ? "line-through" : ""}>{item.label}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- **#762** — Non-embed pages only sent `frame-ancestors 'none'` as their CSP. Added `X-Frame-Options: DENY` plus a full `Content-Security-Policy` (`default-src`, `script-src`, `style-src`, `connect-src` scoped to the app's own API/Horizon/Soroban origins, `img-src`, `frame-ancestors`). Embed routes' permissive policy is untouched.
- **#765** — Added `/recurring` page for supporters to view and cancel their recurring drips. Lists active subscriptions (avatar, creator, amount/asset/frequency, next run date) via `GET /v1/recurring-support`, with an inline two-step confirm before `DELETE /v1/recurring-support/:id`. Backend now also returns `profileAvatarUrl` in the supporter-view response. Linked from the main nav.
- **#766** — Added `/settings` page consolidating email verification (+ resend), the previously-unmounted `NotificationPreferences` component, and a danger-zone profile deletion flow (3-step confirm before `DELETE /profiles/:username`). Linked from the main nav.
- **#768** — Added `OnboardingChecklist`, rendered on the dashboard, tracking 6 setup steps (verify email, add avatar, write bio, connect a social link, create first milestone, share your page) with a progress bar and per-step deep links. Dismissible per-account via localStorage.
- Closes #762 
- Closes #765 
- Closes #766 
- Closes #768 

## Test plan

- [x] `tsc --noEmit` on frontend/backend — no new errors introduced by these changes (pre-existing unrelated errors in test files/other modules left untouched)
- [x] `eslint` on all touched/created files — clean (one pre-existing `<img>` warning in `app-shell.tsx`, unrelated to this change)
- [ ] Manual click-through of `/recurring`, `/settings`, and the dashboard onboarding checklist