### PR TITLE
Fix #780, #784, #785, #791: next/image migration, react-hook-form + react-query proofs-of-concept, config drift

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,22 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        // Wildcard subdomain — matches any Supabase project's Storage host,
+        // since the project ref (NEXT_PUBLIC_SUPABASE_URL) differs per deployment.
+        hostname: "**.supabase.co",
+        pathname: "/storage/v1/object/**",
+      },
+      {
+        // avatarUrl can also come from GitHub profile import (backend/src/app.ts
+        // ghData.avatarUrl), which next/image also needs allowlisted.
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
+  },
   webpack: (config, { isServer }) => {
     if (!isServer) {
       config.resolve.fallback = {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "novasupport-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "@stellar/freighter-api": "^4.1.0",
         "@stellar/stellar-sdk": "^13.3.0",
+        "@tanstack/react-query": "^5.101.4",
         "clsx": "^2.1.1",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
@@ -17,8 +19,10 @@
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.82.0",
         "recharts": "^3.8.1",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
@@ -1045,6 +1049,18 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1922,6 +1938,32 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -7605,6 +7647,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.82.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.82.0.tgz",
+      "integrity": "sha512-Zw/uFZ2dO+02GHlBn7JFGn8kZJ7LdM33B/0BXOovzFay+CMhf94JMw5BVu+F1tVkUKjNvBuaE3fz5BJhga10Tg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
@@ -9843,6 +9901,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,10 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@stellar/freighter-api": "^4.1.0",
     "@stellar/stellar-sdk": "^13.3.0",
+    "@tanstack/react-query": "^5.101.4",
     "clsx": "^2.1.1",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
@@ -20,8 +22,10 @@
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.82.0",
     "recharts": "^3.8.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -13,8 +13,7 @@ import {
 import { motion } from "framer-motion";
 import { formatRateLimitedMessage, parseRateLimitInfo } from "@/lib/rate-limit";
 import { apiFetch } from "@/lib/api-client";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+import { API_BASE_URL } from "@/lib/config";
 
 interface Stats {
   totalEarned: number;

--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { API_BASE_URL } from "@/lib/config";
 import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { EmptyState } from "@/components/empty-state";
@@ -223,9 +224,11 @@ export default function ExplorePage() {
                   className="rounded-[2rem] border border-white/10 bg-white/5 p-6 transition hover:border-mint/30 hover:bg-white/10"
                 >
                   {profile.avatarUrl ? (
-                    <img
+                    <Image
                       src={profile.avatarUrl}
                       alt={profile.displayName}
+                      width={80}
+                      height={80}
                       className="h-20 w-20 rounded-full object-cover mb-4"
                     />
                   ) : (

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { SITE_URL } from "@/lib/config";
+import { Providers } from "./providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -47,7 +48,9 @@ export default function RootLayout({
           }}
         />
       </head>
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { AppShell } from "@/components/app-shell";
 import { ProfileCard } from "@/components/profile-card";
 
@@ -175,9 +176,11 @@ export default async function HomePage() {
               >
                 <div className="flex items-center gap-3">
                   {profile.avatarUrl ? (
-                    <img
+                    <Image
                       src={profile.avatarUrl}
                       alt={profile.displayName}
+                      width={40}
+                      height={40}
                       className="h-10 w-10 rounded-full object-cover"
                     />
                   ) : (

--- a/frontend/src/app/profile/[username]/edit/page.tsx
+++ b/frontend/src/app/profile/[username]/edit/page.tsx
@@ -3,6 +3,9 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 import { getAddress } from "@stellar/freighter-api";
 import { AppShell } from "@/components/app-shell";
 import { API_BASE_URL } from "@/lib/config";
@@ -23,37 +26,43 @@ type ProfileData = {
   acceptedAssets: Array<{ code: string; issuer?: string | null }>;
 };
 
-type FieldErrors = {
-  displayName?: string;
-  bio?: string;
-  websiteUrl?: string;
-  twitterHandle?: string;
-  githubHandle?: string;
-  email?: string;
-};
+const editProfileSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Display name is required.")
+    .max(64, "Max 64 characters."),
+  bio: z.string().max(280, "Max 280 characters."),
+  websiteUrl: z
+    .string()
+    .refine((v) => v === "" || /^https:\/\/.+/.test(v), "Must start with https://"),
+  twitterHandle: z
+    .string()
+    .refine(
+      (v) => v === "" || /^[a-zA-Z0-9_]{1,15}$/.test(v),
+      "Max 15 chars, alphanumeric and underscores only.",
+    ),
+  githubHandle: z
+    .string()
+    .refine(
+      (v) => v === "" || /^[a-zA-Z0-9-]{1,39}$/.test(v),
+      "Max 39 chars, alphanumeric and hyphens only.",
+    ),
+  email: z
+    .string()
+    .refine((v) => v === "" || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v), "Enter a valid email address."),
+});
 
-function validate(form: {
-  displayName: string;
-  bio: string;
-  websiteUrl: string;
-  twitterHandle: string;
-  githubHandle: string;
-  email: string;
-}): FieldErrors {
-  const errors: FieldErrors = {};
-  if (!form.displayName.trim()) errors.displayName = "Display name is required.";
-  else if (form.displayName.length > 64) errors.displayName = "Max 64 characters.";
-  if (form.bio.length > 280) errors.bio = "Max 280 characters.";
-  if (form.websiteUrl && !/^https:\/\/.+/.test(form.websiteUrl))
-    errors.websiteUrl = "Must start with https://";
-  if (form.twitterHandle && !/^[a-zA-Z0-9_]{1,15}$/.test(form.twitterHandle))
-    errors.twitterHandle = "Max 15 chars, alphanumeric and underscores only.";
-  if (form.githubHandle && !/^[a-zA-Z0-9-]{1,39}$/.test(form.githubHandle))
-    errors.githubHandle = "Max 39 chars, alphanumeric and hyphens only.";
-  if (form.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
-    errors.email = "Enter a valid email address.";
-  return errors;
-}
+type EditProfileFormValues = z.infer<typeof editProfileSchema>;
+
+const EMPTY_FORM: EditProfileFormValues = {
+  displayName: "",
+  bio: "",
+  websiteUrl: "",
+  twitterHandle: "",
+  githubHandle: "",
+  email: "",
+};
 
 export default function EditProfilePage() {
   const { username } = useParams<{ username: string }>();
@@ -65,16 +74,19 @@ export default function EditProfilePage() {
   const [submitting, setSubmitting] = useState(false);
   const [authError, setAuthError] = useState<string | null>(null);
   const [walletPrompt, setWalletPrompt] = useState<"locked" | "not-owner" | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
 
-  const [form, setForm] = useState({
-    displayName: "",
-    bio: "",
-    websiteUrl: "",
-    twitterHandle: "",
-    githubHandle: "",
-    email: "",
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors: fieldErrors },
+  } = useForm<EditProfileFormValues>({
+    resolver: zodResolver(editProfileSchema),
+    mode: "onChange",
+    defaultValues: EMPTY_FORM,
   });
+  const bioValue = watch("bio");
 
   const [assets, setAssets] = useState<Asset[]>([]);
   const [newAssetCode, setNewAssetCode] = useState("");
@@ -108,7 +120,7 @@ export default function EditProfilePage() {
         }
 
         setOwnershipChecked(true);
-        setForm({
+        reset({
           displayName: profile.displayName ?? "",
           bio: profile.bio ?? "",
           websiteUrl: profile.websiteUrl ?? "",
@@ -129,14 +141,7 @@ export default function EditProfilePage() {
       }
     }
     init();
-  }, [username, router, ownershipChecked]);
-
-  function setField(field: keyof typeof form) {
-    return (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      setForm((prev) => ({ ...prev, [field]: e.target.value }));
-      setFieldErrors((prev) => ({ ...prev, [field]: undefined }));
-    };
-  }
+  }, [username, router, ownershipChecked, reset]);
 
   function addAsset() {
     const code = newAssetCode.trim().toUpperCase();
@@ -153,23 +158,16 @@ export default function EditProfilePage() {
     setAssets((prev) => prev.filter((a) => a.code !== code));
   }
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const errors = validate(form);
-    if (Object.keys(errors).length > 0) {
-      setFieldErrors(errors);
-      return;
-    }
-
+  async function onSubmit(values: EditProfileFormValues) {
     setSubmitting(true);
     try {
       const profilePayload: Record<string, string | null> = {
-        displayName: form.displayName,
-        bio: form.bio || "",
-        websiteUrl: form.websiteUrl || null,
-        twitterHandle: form.twitterHandle || null,
-        githubHandle: form.githubHandle || null,
-        email: form.email || null,
+        displayName: values.displayName,
+        bio: values.bio || "",
+        websiteUrl: values.websiteUrl || null,
+        twitterHandle: values.twitterHandle || null,
+        githubHandle: values.githubHandle || null,
+        email: values.email || null,
       };
 
       const [profileRes, assetsRes] = await Promise.all([
@@ -291,7 +289,7 @@ export default function EditProfilePage() {
           </Link>
         </div>
 
-        <form onSubmit={handleSubmit} noValidate className="space-y-8">
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-8">
           {/* Profile fields */}
           <section className="rounded-3xl border border-white/10 bg-white/[0.02] p-6 space-y-5">
             <h2 className="text-xs font-semibold uppercase tracking-widest text-steel">
@@ -301,69 +299,63 @@ export default function EditProfilePage() {
             <Field
               label="Display Name"
               required
-              error={fieldErrors.displayName}
+              error={fieldErrors.displayName?.message}
             >
               <input
                 type="text"
-                value={form.displayName}
-                onChange={setField("displayName")}
+                {...register("displayName")}
                 maxLength={64}
                 className={inputCls(!!fieldErrors.displayName)}
                 placeholder="Your name"
               />
             </Field>
 
-            <Field label="Bio" error={fieldErrors.bio}>
+            <Field label="Bio" error={fieldErrors.bio?.message}>
               <textarea
-                value={form.bio}
-                onChange={setField("bio")}
+                {...register("bio")}
                 maxLength={280}
                 rows={3}
                 className={inputCls(!!fieldErrors.bio)}
                 placeholder="Tell supporters about yourself (max 280 chars)"
               />
               <p className="mt-1 text-right text-[10px] text-steel">
-                {form.bio.length}/280
+                {bioValue.length}/280
               </p>
             </Field>
 
-            <Field label="Website URL" error={fieldErrors.websiteUrl}>
+            <Field label="Website URL" error={fieldErrors.websiteUrl?.message}>
               <input
                 type="url"
-                value={form.websiteUrl}
-                onChange={setField("websiteUrl")}
+                {...register("websiteUrl")}
                 className={inputCls(!!fieldErrors.websiteUrl)}
                 placeholder="https://yoursite.com"
               />
             </Field>
 
-            <Field label="Twitter Handle" error={fieldErrors.twitterHandle}>
+            <Field label="Twitter Handle" error={fieldErrors.twitterHandle?.message}>
               <input
                 type="text"
-                value={form.twitterHandle}
-                onChange={setField("twitterHandle")}
+                {...register("twitterHandle")}
                 maxLength={15}
                 className={inputCls(!!fieldErrors.twitterHandle)}
                 placeholder="username (no @)"
               />
             </Field>
 
-            <Field label="GitHub Handle" error={fieldErrors.githubHandle}>
+            <Field label="GitHub Handle" error={fieldErrors.githubHandle?.message}>
               <input
                 type="text"
-                value={form.githubHandle}
-                onChange={setField("githubHandle")}
+                {...register("githubHandle")}
                 maxLength={39}
                 className={inputCls(!!fieldErrors.githubHandle)}
                 placeholder="username"
               />
             </Field>
 
-            <Field label="Email" error={fieldErrors.email}>
+            <Field label="Email" error={fieldErrors.email?.message}>
               <input
                 type="email"
-                value={form.email}
-                onChange={setField("email")}
+                {...register("email")}
                 className={inputCls(!!fieldErrors.email)}
                 placeholder="you@example.com"
               />

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            refetchOnWindowFocus: true,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/frontend/src/app/recurring/page.tsx
+++ b/frontend/src/app/recurring/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { AppShell } from "@/components/app-shell";
 import { Toast } from "@/components/toast";
 import { EmptyState } from "@/components/empty-state";
@@ -98,10 +99,11 @@ export default function RecurringPage() {
               >
                 <div className="flex items-center gap-3 min-w-0">
                   {sub.profileAvatarUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element -- arbitrary external avatar URLs, matches profile-card.tsx convention
-                    <img
+                    <Image
                       src={sub.profileAvatarUrl}
                       alt={sub.profileDisplayName}
+                      width={40}
+                      height={40}
                       className="h-10 w-10 rounded-full object-cover flex-shrink-0"
                     />
                   ) : (

--- a/frontend/src/components/activity-feed.test.tsx
+++ b/frontend/src/components/activity-feed.test.tsx
@@ -4,7 +4,17 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "@testing-library/jest-dom";
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
 
 // ── Stub out Next.js Link so tests don't need a full Next.js context ────────
 vi.mock("next/link", () => ({
@@ -79,7 +89,7 @@ describe("ActivityFeed", () => {
     // Never resolves — keeps the component in loading state
     vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
 
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     // The skeletons are animated pulse divs rendered during loading
     const skeletons = document.querySelectorAll(".animate-pulse");
@@ -88,25 +98,27 @@ describe("ActivityFeed", () => {
 
   it("renders 'No activity yet' when there are no transactions or milestones", async () => {
     stubFetch([]);
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
     await waitFor(() => expect(screen.getByText(/no activity yet/i)).toBeInTheDocument());
   });
 
   it("renders transaction items with correct amount, asset, and timestamp", async () => {
     const tx = makeTransaction("tx-1", { amount: "25.5000000", assetCode: "USDC" });
     stubFetch([tx]);
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/25\.5000000/)).toBeInTheDocument();
-      expect(screen.getByText(/USDC/)).toBeInTheDocument();
+      // The amount appears both in the title and the metadata chip — assert
+      // on presence, not uniqueness, of the text.
+      expect(screen.getAllByText(/25\.5000000/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/USDC/).length).toBeGreaterThan(0);
     });
   });
 
   it("shows 'Load more' button only when items exceed the limit prop", async () => {
     const txs = Array.from({ length: 8 }, (_, i) => makeTransaction(`tx-${i}`));
     stubFetch(txs);
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument();
@@ -116,7 +128,7 @@ describe("ActivityFeed", () => {
   it("does NOT show 'Load more' when items are within the limit", async () => {
     const txs = [makeTransaction("tx-0"), makeTransaction("tx-1")];
     stubFetch(txs);
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     await waitFor(() => expect(screen.queryByText(/no activity yet/i)).not.toBeInTheDocument());
 
@@ -128,7 +140,7 @@ describe("ActivityFeed", () => {
       makeTransaction(`tx-${i}`, { amount: `${i + 1}.0000000` })
     );
     stubFetch(txs);
-    render(<ActivityFeed username="octocat" limit={3} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={3} />);
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /load more/i })).toBeInTheDocument()
@@ -146,7 +158,7 @@ describe("ActivityFeed", () => {
   it("renders milestone reached items with the milestone title", async () => {
     const milestone = makeMilestone("m-1", { title: "First 100 XLM" });
     stubFetch([], [milestone]);
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     await waitFor(() => {
       expect(screen.getByText(/First 100 XLM/)).toBeInTheDocument();
@@ -157,7 +169,7 @@ describe("ActivityFeed", () => {
   it("renders the error message when fetch throws", async () => {
     vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("Network error"))));
 
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     await waitFor(() => {
       expect(screen.getByText(/failed to load activity feed/i)).toBeInTheDocument();
@@ -179,7 +191,7 @@ describe("ActivityFeed", () => {
       })
     );
 
-    render(<ActivityFeed username="octocat" limit={5} />);
+    renderWithQueryClient(<ActivityFeed username="octocat" limit={5} />);
 
     await waitFor(() => {
       expect(screen.getByText(/milestone data could not be loaded/i)).toBeInTheDocument();

--- a/frontend/src/components/activity-feed.tsx
+++ b/frontend/src/components/activity-feed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import {
   TrendingUp,
   Send,
@@ -21,7 +22,6 @@ type ActivityItem = {
   title: string;
   description: string;
   timestamp: string;
-  icon: React.ReactNode;
   metadata?: {
     amount?: string;
     assetCode?: string;
@@ -74,102 +74,84 @@ type ActivityFeedProps = {
   limit?: number;
 };
 
-export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
-  const [activities, setActivities] = useState<ActivityItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [milestonesUnavailable, setMilestonesUnavailable] = useState(false);
-  const [displayedItems, setDisplayedItems] = useState(limit);
-  const [hasMore, setHasMore] = useState(false);
+async function fetchActivities(username: string, signal?: AbortSignal): Promise<{
+  items: ActivityItem[];
+  milestonesUnavailable: boolean;
+}> {
+  const [transactionsRes, milestonesRes] = await Promise.all([
+    fetch(`${API_BASE_URL}/profiles/${username}/transactions?limit=100`, { signal }),
+    fetch(`${API_BASE_URL}/profiles/${username}/milestones`, { signal }).catch(() => null),
+  ]);
 
-  useEffect(() => {
-    const controller = new AbortController();
-    fetchActivities(controller.signal);
-    return () => controller.abort();
-  }, [username]);
+  const transactionsData = transactionsRes.ok
+    ? await transactionsRes.json()
+    : { transactions: [] };
 
-  async function fetchActivities(signal?: AbortSignal) {
-    try {
-      setLoading(true);
-      setError(null);
-      setMilestonesUnavailable(false);
+  const milestonesUnavailable = milestonesRes?.ok !== true;
+  const milestonesData = !milestonesUnavailable
+    ? await milestonesRes!.json()
+    : { milestones: [] };
 
-      const [transactionsRes, milestonesRes] = await Promise.all([
-        fetch(`${API_BASE_URL}/profiles/${username}/transactions?limit=100`, { signal }),
-        fetch(`${API_BASE_URL}/profiles/${username}/milestones`, { signal }).catch(() => null),
-      ]);
+  const items: ActivityItem[] = [];
 
-      const transactionsData = transactionsRes.ok
-        ? await transactionsRes.json()
-        : { transactions: [] };
+  // Add transaction activities
+  const transactions = transactionsData.transactions || [];
+  transactions.forEach((tx: any) => {
+    items.push({
+      id: `tx-${tx.id}`,
+      type: "support",
+      title: `Received ${tx.amount} ${tx.assetCode}`,
+      description: `Support from ${truncateHash(tx.supporterAddress ?? '', 8)}`,
+      timestamp: tx.createdAt,
+      metadata: {
+        amount: tx.amount,
+        assetCode: tx.assetCode,
+        supporter: tx.supporterAddress,
+        txHash: tx.txHash,
+      },
+    });
+  });
 
-      const milestonesOk = milestonesRes?.ok === true;
-      if (!milestonesOk) {
-        setMilestonesUnavailable(true);
-      }
-      const milestonesData = milestonesOk
-        ? await milestonesRes!.json()
-        : { milestones: [] };
-
-      const items: ActivityItem[] = [];
-
-      // Add transaction activities
-      const transactions = transactionsData.transactions || [];
-      transactions.forEach((tx: any) => {
-        items.push({
-          id: `tx-${tx.id}`,
-          type: "support",
-          title: `Received ${tx.amount} ${tx.assetCode}`,
-          description: `Support from ${truncateHash(tx.supporterAddress ?? '', 8)}`,
-          timestamp: tx.createdAt,
-          icon: getActivityIcon("support"),
-          metadata: {
-            amount: tx.amount,
-            assetCode: tx.assetCode,
-            supporter: tx.supporterAddress,
-            txHash: tx.txHash,
-          },
-        });
+  // Add milestone activities
+  const milestones = milestonesData.milestones || [];
+  milestones.forEach((milestone: any) => {
+    if (milestone.reachedAt) {
+      items.push({
+        id: `milestone-${milestone.id}`,
+        type: "milestone",
+        title: `Milestone reached: ${milestone.title}`,
+        description: `Goal of ${milestone.targetAmount} ${milestone.assetCode} achieved`,
+        timestamp: milestone.reachedAt,
+        metadata: {
+          milestone: milestone.title,
+          amount: milestone.targetAmount,
+          assetCode: milestone.assetCode,
+        },
       });
-
-      // Add milestone activities
-      const milestones = milestonesData.milestones || [];
-      milestones.forEach((milestone: any) => {
-        if (milestone.reachedAt) {
-          items.push({
-            id: `milestone-${milestone.id}`,
-            type: "milestone",
-            title: `Milestone reached: ${milestone.title}`,
-            description: `Goal of ${milestone.targetAmount} ${milestone.assetCode} achieved`,
-            timestamp: milestone.reachedAt,
-            icon: getActivityIcon("milestone"),
-            metadata: {
-              milestone: milestone.title,
-              amount: milestone.targetAmount,
-              assetCode: milestone.assetCode,
-            },
-          });
-        }
-      });
-
-      // Sort by timestamp (newest first)
-      items.sort(
-        (a, b) =>
-          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
-      );
-
-      setActivities(items);
-      setHasMore(items.length > limit);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      console.error("Failed to fetch activities:", err);
-      setError("Failed to load activity feed");
-    } finally {
-      if (!signal?.aborted) setLoading(false);
     }
-  }
+  });
 
-  if (loading) {
+  // Sort by timestamp (newest first)
+  items.sort(
+    (a, b) =>
+      new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+  );
+
+  return { items, milestonesUnavailable };
+}
+
+export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
+  const [displayedItems, setDisplayedItems] = useState(limit);
+
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ["activity-feed", username],
+    queryFn: ({ signal }) => fetchActivities(username, signal),
+  });
+
+  const activities = data?.items ?? [];
+  const milestonesUnavailable = data?.milestonesUnavailable ?? false;
+
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="space-y-4 w-full max-w-md">
@@ -187,7 +169,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
   if (error) {
     return (
       <div className="rounded-lg bg-red-500/10 border border-red-500/20 p-4 text-sm text-red-400">
-        {error}
+        Failed to load activity feed
       </div>
     );
   }
@@ -203,7 +185,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
           <AlertTriangle className="h-4 w-4 flex-shrink-0" />
           <span>Milestone data could not be loaded — the feed may be incomplete.</span>
           <button
-            onClick={() => fetchActivities()}
+            onClick={() => refetch()}
             className="ml-auto flex-shrink-0 text-xs underline underline-offset-2 hover:text-yellow-300 transition"
           >
             Retry
@@ -231,7 +213,7 @@ export function ActivityFeed({ username, limit = 10 }: ActivityFeedProps) {
                 <div className="flex gap-4">
                   {/* Icon */}
                   <div className="flex-shrink-0 flex items-center justify-center h-10 w-10 rounded-full bg-white/5">
-                    {activity.icon}
+                    {getActivityIcon(activity.type)}
                   </div>
 
                   {/* Content */}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { WalletConnect } from "@/components/wallet-connect";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { getNetworkLabel } from "@/lib/stellar";
@@ -167,9 +168,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                         className="flex items-center gap-3 px-4 py-3 hover:bg-white/5 dark:hover:bg-white/10 transition border-b border-white/5 dark:border-white/10 last:border-0"
                       >
                         {result.avatarUrl ? (
-                          <img
+                          <Image
                             src={result.avatarUrl}
                             alt={result.displayName}
+                            width={40}
+                            height={40}
                             className="h-10 w-10 rounded-full object-cover"
                           />
                         ) : (

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState, useCallback, KeyboardEvent } from "react";
+import Image from "next/image";
 import { isValidStellarAddress, stellarExpertUrl } from "@/lib/stellar";
 import { useToast } from "@/lib/use-toast";
 import { SITE_URL } from "@/lib/config";
@@ -172,7 +173,13 @@ export function ProfileCard({
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex gap-4">
             {avatarUrl ? (
-              <img src={avatarUrl} alt={displayName} className="w-16 h-16 rounded-full object-cover" />
+              <Image
+                src={avatarUrl}
+                alt={displayName}
+                width={64}
+                height={64}
+                className="w-16 h-16 rounded-full object-cover"
+              />
             ) : (
               <div className="w-16 h-16 rounded-full bg-indigo-600 flex items-center justify-center text-white text-xl font-bold">
                 {(displayName?.slice(0, 2) || '?').toUpperCase()}


### PR DESCRIPTION
Closes #780 
Closes #784  
Closes #785  
Closes #791 

## Summary

- **#780** — Converted avatar `<img>` tags to `next/image`: `profile-card.tsx` (the file named in the issue), plus `app/page.tsx`, `explore/page.tsx`, `app-shell.tsx`, and `recurring/page.tsx` (found via a codebase audit). Added `images.remotePatterns` to `next.config.mjs` for Supabase Storage (wildcard subdomain, since the project ref differs per deployment) and `avatars.githubusercontent.com` (avatarUrl can also come from GitHub profile import, per `backend/src/app.ts`'s `ghData.avatarUrl`). Left `opengraph-image.tsx` (requires raw `<img>` for `next/og`'s satori renderer) and `embed-widget.tsx` (deliberately permissive embed route, out of scope) untouched. **Known limitation:** `avatarUrl` is an unrestricted URL in the schema, so a custom avatar on a host outside these two allowlisted ones will now fail to render via `next/image` instead of degrading gracefully like a plain `<img>` would — flagged as a follow-up, not fixed here.
- **#791** — `dashboard/page.tsx` now imports `API_BASE_URL` from `@/lib/config` instead of its own hardcoded fallback (`http://localhost:4000`, which silently diverged from `config.ts`'s own default of `http://localhost:3001`).
- **#785** — Installed `@tanstack/react-query`, added a `providers.tsx` client component wrapping the app in `QueryClientProvider` (`layout.tsx` stays a server component), and converted `activity-feed.tsx` to `useQuery` as the suggested proof-of-concept. Updated `activity-feed.test.tsx` to wrap renders in a `QueryClientProvider` and fixed a pre-existing flaky assertion in the same file while there.
- **#784** — Installed `react-hook-form`, `@hookform/resolvers`, and `zod`. Refactored `profile/[username]/edit/page.tsx`'s ~10 `useState` declarations into a single `useForm()` with a zod schema mirroring the removed `validate()` function's exact rules/messages. Per the issue, started with `edit/page.tsx` as the smaller scope — `create/page.tsx` is a follow-up. The accepted-assets list (dynamic add/remove) stays as local state since it isn't a simple form field.

## Test plan

- [x] `npx tsc --noEmit` — no new errors in any touched file
- [x] `npx eslint <touched files>` — clean (one pre-existing unrelated warning in `explore/page.tsx`)
- [x] `npx vitest run` (full frontend suite) — same 50 pre-existing failures before and after this branch (confirmed via `git stash`/`git stash pop` comparison); `activity-feed.test.tsx` (9 tests) passes after being updated for the `QueryClientProvider` requirement