### PR TITLE
fix(backend): server-side logout revocation and rate limit federation…

### DIFF
--- a/backend/prisma/migrations/20260724000000_add_revoked_tokens/migration.sql
+++ b/backend/prisma/migrations/20260724000000_add_revoked_tokens/migration.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "revoked_tokens" (
+    "jti" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "revoked_tokens_pkey" PRIMARY KEY ("jti")
+);
+
+CREATE INDEX "revoked_tokens_expiresAt_idx" ON "revoked_tokens"("expiresAt");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -242,6 +242,15 @@ model AuthChallenge {
   @@map("auth_challenges")
 }
 
+model RevokedToken {
+  jti       String   @id
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+
+  @@index([expiresAt])
+  @@map("revoked_tokens")
+}
+
 model CircuitBreakerState {
   name          String    @id
   state         String

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -274,6 +274,16 @@ function createRateLimiters() {
     message: { error: "Too many auth attempts, please try again later." },
   });
 
+  // Federation / stellar.toml limiter — 30 requests per minute per IP (#763)
+  const federationLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === "test",
+    message: { error: "Too many requests, please try again later." },
+  });
+
   return {
     globalLimiter,
     writeLimiter,
@@ -281,6 +291,7 @@ function createRateLimiters() {
     resendLimiter,
     viewCountLimiter,
     authLimiter,
+    federationLimiter,
   };
 }
 
@@ -375,6 +386,7 @@ export function createApp(customLogger?: Logger) {
     resendLimiter,
     viewCountLimiter,
     authLimiter,
+    federationLimiter,
   } = createRateLimiters();
 
   const swaggerSpec = swaggerJsdoc({
@@ -478,7 +490,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   // Spec: https://developers.stellar.org/docs/learn/encyclopedia/network-configuration/stellar-toml
   let tomlCache: { body: string; expiresAt: number } | null = null;
 
-  app.get("/.well-known/stellar.toml", async (_req, res) => {
+  app.get("/.well-known/stellar.toml", federationLimiter, async (_req, res) => {
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Cache-Control", "public, max-age=60");
     res.setHeader("Content-Type", "text/plain; charset=utf-8");
@@ -854,6 +866,40 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     });
 
     res.json({ token, walletAddress, userId: user.id });
+  });
+
+  /**
+   * @openapi
+   * /auth/logout:
+   *   post:
+   *     summary: Invalidate the current session server-side
+   *     description: |
+   *       Revokes the JWT presented in the Authorization header or auth_token cookie by
+   *       storing its jti until expiry, and clears the auth_token cookie.
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Logged out
+   *       401:
+   *         description: Missing or invalid token
+   */
+  v1Router.post("/auth/logout", requireAuth, async (req, res) => {
+    try {
+      if (req.auth?.jti && req.auth.exp) {
+        await prisma.revokedToken.upsert({
+          where: { jti: req.auth.jti },
+          create: { jti: req.auth.jti, expiresAt: new Date(req.auth.exp * 1000) },
+          update: {},
+        });
+      }
+
+      res.clearCookie("auth_token");
+      res.json({ ok: true });
+    } catch (e: unknown) {
+      req.log.error({ err: e }, "database error during logout");
+      return sendError(res, 500, "Internal server error");
+    }
   });
 
   // ── List profiles with pagination ──────────────────────────────────────
@@ -4478,7 +4524,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *       404:
    *         description: No profile found for that username
    */
-  app.get("/federation", async (req, res) => {
+  app.get("/federation", federationLimiter, async (req, res) => {
     // Stellar spec requires CORS open to all origins on this endpoint
     res.setHeader("Access-Control-Allow-Origin", "*");
 

--- a/backend/src/auth.test.ts
+++ b/backend/src/auth.test.ts
@@ -298,7 +298,7 @@ async function main() {
     const res = mockResponse();
     const next = mockNext();
 
-    requireAuth(req, res, next);
+    await requireAuth(req, res, next);
 
     assert.ok(next.called, "next() should be called for valid token");
     assert.ok(req.auth !== undefined, "req.auth should be set");
@@ -310,7 +310,7 @@ async function main() {
     const res = mockResponse();
     const next = mockNext();
 
-    requireAuth(req, res, next);
+    await requireAuth(req, res, next);
 
     assert.equal(next.called, false, "next() should not be called");
     assert.equal(res.statusCode, 401, "Should return 401 status");
@@ -327,7 +327,7 @@ async function main() {
     const res = mockResponse();
     const next = mockNext();
 
-    requireAuth(req, res, next);
+    await requireAuth(req, res, next);
 
     assert.equal(next.called, false, "next() should not be called");
     assert.equal(res.statusCode, 401, "Should return 401 status");
@@ -340,7 +340,7 @@ async function main() {
     const res = mockResponse();
     const next = mockNext();
 
-    requireAuth(req, res, next);
+    await requireAuth(req, res, next);
 
     assert.equal(next.called, false, "next() should not be called");
     assert.equal(res.statusCode, 401, "Should return 401 status");
@@ -357,7 +357,7 @@ async function main() {
     const res = mockResponse();
     const next = mockNext();
 
-    requireAuth(req, res, next);
+    await requireAuth(req, res, next);
 
     assert.equal(next.called, false, "next() should not be called");
     assert.equal(res.statusCode, 401, "Should return 401 status");
@@ -493,7 +493,7 @@ async function main() {
     });
     const res1 = mockResponse();
     const next1 = mockNext();
-    requireAuth(req1, res1, next1);
+    await requireAuth(req1, res1, next1);
 
     // Test optionalAuth with same token
     const req2 = mockRequest({

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -4,6 +4,7 @@ import jwt from "jsonwebtoken";
 import { randomBytes } from "node:crypto";
 import { Keypair, StrKey } from "@stellar/stellar-sdk";
 import { logger } from "./logger.js";
+import { prisma } from "./db.js";
 
 const JWT_SECRET = process.env.JWT_SECRET;
 const JWT_EXPIRY = "1h";
@@ -17,6 +18,8 @@ const JWT_SECRET_VALIDATED: string = JWT_SECRET;
 export type AuthContext = {
   walletAddress: string;
   userId?: string;
+  jti?: string;
+  exp?: number;
 };
 
 declare module "express" {
@@ -51,7 +54,7 @@ export function signJWT(walletAddress: string, userId?: string): string {
   return jwt.sign(
     { walletAddress, userId },
     JWT_SECRET_VALIDATED,
-    { expiresIn: JWT_EXPIRY }
+    { expiresIn: JWT_EXPIRY, jwtid: randomBytes(16).toString("hex") }
   );
 }
 
@@ -66,7 +69,7 @@ export function verifyJWT(token: string): AuthContext | null {
 
 // Accepts token from Authorization: Bearer header (API consumers)
 // OR from the httpOnly auth_token cookie set by POST /auth/verify (#759)
-export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   // 1. Try Authorization header first (API clients, mobile)
   const authHeader = req.headers.authorization;
   let token: string | undefined;
@@ -88,6 +91,22 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
   if (!auth) {
     res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
     return;
+  }
+
+  if (auth.jti) {
+    try {
+      const revoked = await prisma.revokedToken.findUnique({
+        where: { jti: auth.jti },
+      });
+      if (revoked) {
+        res.status(401).json({ error: "Unauthorized: Token has been revoked" });
+        return;
+      }
+    } catch (error) {
+      logger.error({ error }, "Failed to check token revocation status");
+      res.status(500).json({ error: "Internal server error" });
+      return;
+    }
   }
 
   req.auth = auth;


### PR DESCRIPTION


Add POST /v1/auth/logout to revoke the current JWT server-side: JWTs now carry a jti claim, revoked jti values are stored in a new RevokedToken table until expiry, requireAuth rejects revoked tokens, and logout clears the auth_token cookie.

Add a federationLimiter (30 req/min per IP) to GET /federation and GET /.well-known/stellar.toml to prevent unauthenticated enumeration and abuse.

Closes #761
Closes #763
Closes #770
Closes #760

