### PR TITLE
Fix/schema seo dashboard issues

### DIFF
--- a/backend/prisma/migrations/20260724010000_add_recurring_support_asset_issuer/migration.sql
+++ b/backend/prisma/migrations/20260724010000_add_recurring_support_asset_issuer/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "RecurringSupport" ADD COLUMN "assetIssuer" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -179,6 +179,7 @@ model RecurringSupport {
   profileId        String
   amount           Decimal                     @db.Decimal(18, 7)
   assetCode        String                      @default("XLM")
+  assetIssuer      String?
   frequency        String
   nextRunAt        DateTime                    @default(now())
   status           String                      @default("active")

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2642,7 +2642,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *       500:
    *         description: Internal server error
    */
-  v1Router.get("/profiles/:username/transactions/export", requireAuth, async (req, res) => {
+  v1Router.get(["/profiles/:username/transactions/export", "/profiles/:username/transactions/csv"], requireAuth, async (req, res) => {
     const username = req.params.username as string;
     const { startDate, endDate, taxYear } = req.query;
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3171,6 +3171,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         if (
           new Decimal(execution.recurringSupport.amount).toString() !== new Decimal(parsed.data.amount).toString() ||
           execution.recurringSupport.assetCode !== parsed.data.assetCode ||
+          (execution.recurringSupport.assetIssuer ?? null) !== (parsed.data.assetIssuer ?? null) ||
           execution.recurringSupport.profile.walletAddress !== parsed.data.recipientAddress
         ) {
           return sendError(res, 400, "Transaction details do not match recurring support subscription");
@@ -4087,10 +4088,11 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   // ── Recurring Support ───────────────────────────────────────────────────
 
   const recurringSchema = z.object({
-    profileId:  z.string().min(1),
-    amount:     z.string().regex(/^\d+(\.\d{1,7})?$/, "amount must be a positive decimal with up to 7 decimal places").refine(v => parseFloat(v) > 0, "amount must be greater than zero"),
-    assetCode:  z.string().min(1).max(12).optional().default("XLM"),
-    frequency:  z.enum(["weekly", "monthly"]),
+    profileId:   z.string().min(1),
+    amount:      z.string().regex(/^\d+(\.\d{1,7})?$/, "amount must be a positive decimal with up to 7 decimal places").refine(v => parseFloat(v) > 0, "amount must be greater than zero"),
+    assetCode:   z.string().min(1).max(12).optional().default("XLM"),
+    assetIssuer: z.string().optional().nullable(),
+    frequency:   z.enum(["weekly", "monthly"]),
   });
 
   v1Router.post("/recurring-support", requireAuth, writeLimiter, async (req, res) => {
@@ -4098,7 +4100,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     if (!parsed.success) {
       return sendError(res, 400, parsed.error.issues.map(i => i.message).join("; "));
     }
-    const { profileId, amount, assetCode, frequency } = parsed.data;
+    const { profileId, amount, assetCode, assetIssuer, frequency } = parsed.data;
 
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
@@ -4128,6 +4130,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         profileId,
         amount,
         assetCode,
+        assetIssuer: assetIssuer ?? null,
         frequency,
         nextRunAt,
       },
@@ -4159,6 +4162,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         supporterAddress: s.supporter?.email ?? null,
         amount: s.amount.toString(),
         assetCode: s.assetCode,
+        assetIssuer: s.assetIssuer,
         frequency: s.frequency,
         nextRunAt: s.nextRunAt,
         status: s.status,
@@ -4182,6 +4186,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       profileAvatarUrl: s.profile.avatarUrl,
       amount: s.amount.toString(),
       assetCode: s.assetCode,
+      assetIssuer: s.assetIssuer,
       frequency: s.frequency,
       nextRunAt: s.nextRunAt,
       status: s.status,
@@ -4193,8 +4198,9 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     status: z.enum(["active", "paused", "cancelled"]).optional(),
     frequency: z.enum(["weekly", "monthly"]).optional(),
     amount: z.string().regex(/^\d+(\.\d{1,7})?$/).refine(v => parseFloat(v) > 0).optional(),
-  }).refine((data) => data.status || data.frequency || data.amount, {
-    message: "At least one of status, frequency, or amount is required",
+    assetIssuer: z.string().optional().nullable(),
+  }).refine((data) => data.status || data.frequency || data.amount || data.assetIssuer !== undefined, {
+    message: "At least one field to update is required",
   });
 
   v1Router.patch("/recurring-support/:id", requireAuth, writeLimiter, async (req, res) => {
@@ -4212,7 +4218,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
     if (!subscription) return sendError(res, 404, "Recurring support not found");
     if (subscription.supporterId !== user.id) return sendError(res, 403, "Forbidden");
 
-    const { status, frequency, amount } = parsed.data;
+    const { status, frequency, amount, assetIssuer } = parsed.data;
 
     // Recalculate nextRunAt when frequency changes
     let nextRunAt: Date | undefined;
@@ -4231,6 +4237,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         ...(status ? { status } : {}),
         ...(frequency ? { frequency } : {}),
         ...(amount ? { amount } : {}),
+        ...(assetIssuer !== undefined ? { assetIssuer } : {}),
         ...(nextRunAt ? { nextRunAt } : {}),
       },
     });

--- a/backend/src/services/drip-scheduler.test.ts
+++ b/backend/src/services/drip-scheduler.test.ts
@@ -124,13 +124,7 @@ test("processDueRecurringSupports does not overflow into the wrong month at mont
     recurringSupports: [makeSupport({ frequency: "monthly", nextRunAt: jan31 })],
   });
 
-  const originalNow = Date.now;
-  Date.now = () => jan31.getTime();
-  try {
-    await processDueRecurringSupports(mockPrisma as any);
-  } finally {
-    Date.now = originalNow;
-  }
+  await processDueRecurringSupports(mockPrisma as any, jan31);
 
   const updateCall = getFirstArg<TxUpdateArg>(mockPrisma.txRecurringSupportUpdate);
   // Jan 31 + 1 month should clamp to Feb 29 (2024 is a leap year), not roll

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -18,8 +18,7 @@ function addMonths(date: Date, months: number): Date {
   return result;
 }
 
-export async function processDueRecurringSupports(prismaClient = prisma) {
-  const now = new Date();
+export async function processDueRecurringSupports(prismaClient = prisma, now = new Date()) {
   let cursor: string | undefined;
 
   do {
@@ -80,6 +79,8 @@ export async function processDueRecurringSupports(prismaClient = prisma) {
         dripId: support.id,
         profileId: support.profileId,
         amount: support.amount.toString(),
+        assetCode: support.assetCode,
+        assetIssuer: support.assetIssuer,
       }, "Processed due recurring support");
       Metrics.dripsProcessed();
 

--- a/frontend/src/app/dashboard/[campaignId]/page.tsx
+++ b/frontend/src/app/dashboard/[campaignId]/page.tsx
@@ -328,7 +328,6 @@ export default function DashboardPage() {
   const [assetBreakdown, setAssetBreakdown] = useState<AssetBreakdownEntry[]>(
     [],
   );
-  const [assetTotal, setAssetTotal] = useState(0);
   const [selectedPeriod, setSelectedPeriod] = useState<ChartRange>("30D");
   const [chartLoading, setChartLoading] = useState(true);
   const [connectedWallet, setConnectedWallet] = useState("");
@@ -385,7 +384,6 @@ export default function DashboardPage() {
             total: number;
           };
           setAssetBreakdown(assetsJson.breakdown ?? []);
-          setAssetTotal(assetsJson.total ?? 0);
         }
       } catch (err: any) {
         setError(err.message);
@@ -598,22 +596,19 @@ export default function DashboardPage() {
     setCsvLoading(true);
     try {
       const res = await apiFetch(
-        `${API_BASE_URL}/profiles/${campaignId}/transactions?limit=50`,
+        `${API_BASE_URL}/profiles/${campaignId}/transactions/csv`,
       );
-      if (!res.ok) throw new Error("Failed to fetch full transactions");
-      const json = (await res.json()) as {
-        transactions?: Array<Record<string, unknown>>;
-      };
-      const rows: TransactionCsvRow[] = (json.transactions ?? []).map((tx) => ({
-        createdAt: toString(tx.createdAt, new Date().toISOString()),
-        amount: toString(tx.amount, "0"),
-        assetCode: toString(tx.assetCode, "XLM"),
-        supporterAddress: toString(tx.supporterAddress, ""),
-        message: toString(tx.message, ""),
-        status: toString(tx.status, ""),
-        txHash: toString(tx.txHash, ""),
-      }));
-      downloadCsv(rows);
+      if (!res.ok) throw new Error("Failed to fetch transaction CSV");
+      const csv = await res.text();
+      const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `novasupport-transactions-${campaignId}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
     } catch (err: any) {
       setError(err.message ?? "Failed to download CSV");
     } finally {
@@ -1000,15 +995,18 @@ export default function DashboardPage() {
                 )}
               </div>
               {assetBreakdown.length > 0 && (
-                <div className="mt-4 border-t border-white/10 pt-4 text-center">
-                  <p className="text-[10px] uppercase tracking-widest text-steel">
+                <div className="mt-4 border-t border-white/10 pt-4 text-center space-y-1">
+                  <p className="text-[10px] uppercase tracking-widest text-steel mb-2">
                     Total Earned
                   </p>
-                  <p className="mt-1 text-xl font-bold text-white tabular-nums">
-                    {assetTotal.toLocaleString(undefined, {
-                      maximumFractionDigits: 7,
-                    })}
-                  </p>
+                  {assetBreakdown.map((a) => (
+                    <p key={a.assetCode} className="text-xl font-bold text-white tabular-nums">
+                      {a.amount.toLocaleString(undefined, {
+                        maximumFractionDigits: 7,
+                      })}{" "}
+                      {a.assetCode}
+                    </p>
+                  ))}
                 </div>
               )}
             </motion.div>

--- a/frontend/src/app/profile/[username]/page.tsx
+++ b/frontend/src/app/profile/[username]/page.tsx
@@ -28,6 +28,9 @@ type Profile = {
   bio: string;
   walletAddress: string;
   avatarUrl?: string | null;
+  websiteUrl?: string | null;
+  twitterHandle?: string | null;
+  githubHandle?: string | null;
   acceptedAssets: Array<{ code: string; issuer?: string | null }>;
   emailVerified?: boolean;
 };
@@ -222,8 +225,37 @@ export default async function ProfilePage({ params }: PageProps) {
       )
     : null;
 
+  const sameAs = [
+    profile.websiteUrl,
+    profile.twitterHandle
+      ? `https://twitter.com/${profile.twitterHandle.replace(/^@/, "")}`
+      : null,
+    profile.githubHandle
+      ? `https://github.com/${profile.githubHandle.replace(/^@/, "")}`
+      : null,
+  ].filter(Boolean) as string[];
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "mainEntity": {
+      "@type": "Person",
+      "name": profile.displayName,
+      "alternateName": profile.username,
+      "description": profile.bio || undefined,
+      "image": profile.avatarUrl || undefined,
+      "url": `${SITE_URL}/profile/${profile.username}`,
+      "identifier": profile.walletAddress,
+      ...(sameAs.length > 0 ? { sameAs } : {}),
+    },
+  };
+
   return (
     <AppShell>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-8 items-start animate-fade-in">
         <div className="space-y-12">
           <div className="space-y-3">

--- a/frontend/src/components/support-panel.tsx
+++ b/frontend/src/components/support-panel.tsx
@@ -185,6 +185,7 @@ export function SupportPanel({
             profileId,
             amount,
             assetCode: paymentAsset.code,
+            assetIssuer: paymentAsset.issuer || undefined,
             frequency,
           }),
         }).catch(() => {


### PR DESCRIPTION
## Summary of Fixes
## [Schema] RecurringSupport model missing assetIssuer field: Added assetIssuer String? to schema.prisma, created migration 20260724010000_add_recurring_support_asset_issuer, updated CRUD endpoints in app.ts, drip scheduler logging, transaction execution validation, and support-panel.tsx.
## [SEO] Add JSON-LD structured data to creator profile pages: Generated and injected ProfilePage & Person JSON-LD schema (application/ld+json) with name, bio, image, wallet address, and social links on creator profile pages.
## [Frontend] Dashboard 'Total Earned' sums amounts across all asset types: Removed unitless cross-currency sum assetTotal and replaced it with a per-asset breakdown display (e.g. 100 USDC, 5 XLM).
## [Frontend] Dashboard CSV export hardcoded to limit=50: Added /profiles/:username/transactions/csv backend endpoint alias and updated handleDownloadCsv() in the dashboard to fetch the full CSV export stream directly.


fix(backend): add assetIssuer to RecurringSupport model and endpoints (Closes #803)
fix(seo): add JSON-LD structured data to creator profile pages (Closes #783)
fix(frontend): show per-asset breakdown instead of cross-currency total earned (Closes #821)
fix(frontend): use dedicated CSV export endpoint for full transaction export (Closes #822)
