### PR TITLE
Fix precision and caching issues in backend services

### DIFF
--- a/backend/src/services/soroban-rpc-client.ts
+++ b/backend/src/services/soroban-rpc-client.ts
@@ -159,6 +159,7 @@ export function createSorobanRpcClient(
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(requestBody),
+        signal: AbortSignal.timeout(15_000),
       });
 
       if (!response.ok) {
@@ -191,6 +192,7 @@ async function getLatestLedger(rpcUrl: string): Promise<number> {
       id: randomUUID(),
       method: "getLatestLedger",
     }),
+    signal: AbortSignal.timeout(15_000),
   });
 
   if (!response.ok) {

--- a/backend/src/services/verify-transaction.ts
+++ b/backend/src/services/verify-transaction.ts
@@ -11,6 +11,11 @@ export interface ExpectedTxDetails {
 // Module-level cache shared across all calls in the same process
 const verificationCache = new Map<string, { result: boolean; timestamp: number }>();
 export const VERIFICATION_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+export const NEGATIVE_CACHE_TTL = 30 * 1000; // 30 seconds for false/error results
+
+function normalizeAmount(amount: string): string {
+  return parseFloat(amount).toFixed(7);
+}
 
 export function clearVerificationCache(): void {
   verificationCache.clear();
@@ -52,7 +57,7 @@ async function validatePaymentDetails(
       };
       if (
         p.to === expected.recipientAddress &&
-        parseFloat(p.amount) === parseFloat(expected.amount) &&
+        normalizeAmount(p.amount) === normalizeAmount(expected.amount) &&
         isAssetMatch(p, expected.assetCode, expected.assetIssuer)
       ) {
         return true;
@@ -65,7 +70,7 @@ async function validatePaymentDetails(
       if (
         wantNative &&
         c.account === expected.recipientAddress &&
-        parseFloat(c.starting_balance) === parseFloat(expected.amount)
+        normalizeAmount(c.starting_balance) === normalizeAmount(expected.amount)
       ) {
         return true;
       }
@@ -96,7 +101,7 @@ async function validatePaymentDetails(
       if (
         p.to === expected.recipientAddress &&
         receivedAmount !== undefined &&
-        parseFloat(receivedAmount) === parseFloat(expected.amount) &&
+        normalizeAmount(receivedAmount) === normalizeAmount(expected.amount) &&
         isAssetMatch(p, expected.assetCode, expected.assetIssuer)
       ) {
         return true;
@@ -141,8 +146,11 @@ export async function verifyTransaction(
 ): Promise<boolean | "error"> {
   const cacheKey = makeCacheKey(txHash, expected);
   const cached = verificationCache.get(cacheKey);
-  if (cached && Date.now() - cached.timestamp < VERIFICATION_CACHE_TTL) {
-    return cached.result;
+  if (cached) {
+    const ttl = cached.result === true ? VERIFICATION_CACHE_TTL : NEGATIVE_CACHE_TTL;
+    if (Date.now() - cached.timestamp < ttl) {
+      return cached.result;
+    }
   }
 
   for (let attempt = 1; attempt <= retries; attempt++) {
@@ -150,12 +158,14 @@ export async function verifyTransaction(
       const tx = await server.transactions().transaction(txHash).call();
 
       if (!tx.successful) {
+        verificationCache.set(cacheKey, { result: false, timestamp: Date.now() });
         return false;
       }
 
       if (expected) {
         const valid = await validatePaymentDetails(server, txHash, expected);
         if (!valid) {
+          verificationCache.set(cacheKey, { result: false, timestamp: Date.now() });
           return false;
         }
       }
@@ -164,6 +174,7 @@ export async function verifyTransaction(
       return true;
     } catch (e: unknown) {
       if (isHorizon404(e)) {
+        verificationCache.set(cacheKey, { result: false, timestamp: Date.now() });
         return false;
       }
 
@@ -177,5 +188,6 @@ export async function verifyTransaction(
     }
   }
 
+  verificationCache.set(cacheKey, { result: "error" as any, timestamp: Date.now() });
   return "error";
 }

--- a/backend/src/services/weekly-digest.ts
+++ b/backend/src/services/weekly-digest.ts
@@ -82,7 +82,7 @@ export async function sendWeeklyDigests(prismaClient = prisma) {
         if (txCount === 0) continue;
 
         const assetBreakdown = assetGroups
-          .map((g) => `${g._sum.amount?.toFixed(7) ?? "0"} ${g.assetCode}`)
+          .map((g) => `${g._sum.amount?.toString() ?? "0"} ${g.assetCode}`)
           .join(", ");
 
         const milestonesSection =


### PR DESCRIPTION
Closes #819, closes #824, closes #825, closes #828

## Summary
This PR fixes 4 backend issues related to precision handling, caching, and timeout management in Stellar Wave services.

## Changes

### Issue #819: weekly-digest precision loss
- Changed `g._sum.amount?.toFixed(7)` to `g._sum.amount?.toString()` 
- Prisma Decimal objects should not implicitly convert to Number via toFixed(), which loses precision for large amounts

### Issue #824: Unoptimized verification caching
- Now cache negative results (404s and errors) with a 30-second TTL
- Positive results still cached for 1 hour
- Prevents attackers from flooding Horizon with fake txHash values

### Issue #825: Float equality for Stellar amounts
- Created `normalizeAmount()` helper to normalize amounts to 7 decimal places
- Compare amounts as fixed-precision strings instead of floats
- Fixes false negatives for amounts with 15+ significant digits

### Issue #828: Missing RPC timeout
- Added 15-second timeout to both `fetch()` calls in soroban-rpc-client
- Uses `AbortSignal.timeout(15_000)` to prevent indefinite hangs on slow RPC nodes
- Affects both `getEvents()` and `getLatestLedger()` methods

## Testing
- All changes are defensive (handle edge cases better)
- Existing tests should still pass
- Recommend testing with large amounts and network latency scenarios