### PR TITLE
fix: backend type safety and robustness improvements

### DIFF
--- a/backend/src/services/badge-awarder.ts
+++ b/backend/src/services/badge-awarder.ts
@@ -82,6 +82,12 @@ export async function checkAndAwardBadges(profileId: string, prismaClient = pris
           case "milestone_reached":
             shouldAward = milestonesReached >= 1;
             break;
+          default:
+            logger.warn(
+              { criteria: badge.criteria, badgeId: badge.id },
+              "Unknown badge criteria — badge will never be auto-awarded",
+            );
+            break;
         }
 
         if (shouldAward) {

--- a/backend/src/services/event-indexer.ts
+++ b/backend/src/services/event-indexer.ts
@@ -16,7 +16,7 @@
 // walletAddress. This keeps the indexer eventually consistent with the
 // profile registry without blocking the hot path.
 
-import type { PrismaClient } from "@prisma/client";
+import type { PrismaClient, Prisma } from "@prisma/client";
 import { logger } from "../logger.js";
 import { Metrics } from "../metrics.js";
 
@@ -197,6 +197,11 @@ export class EventIndexer {
             status: "SUCCESS",
           },
         });
+        // Heuristic: assume createdAt == updatedAt means this was an INSERT.
+        // On fast systems (ms-resolution timestamps), a duplicate event can land
+        // in the same millisecond as the insert, miscounting as an update.
+        // TODO: Use Postgres INSERT ... ON CONFLICT DO UPDATE RETURNING xmax,
+        // where xmax = 0 means INSERT and non-zero means UPDATE, for exact detection.
         if (result.createdAt.getTime() === result.updatedAt.getTime()) {
           ingested += 1;
         }
@@ -219,6 +224,7 @@ export class EventIndexer {
     const orphans = await this.prisma.supportTransaction.findMany({
       where: { profileId: "__orphan__" },
       select: { id: true, recipientAddress: true },
+      take: 100,
     });
 
     if (orphans.length === 0) return 0;
@@ -282,7 +288,7 @@ export class EventIndexer {
   }
 
   private async writeCursorWithinTx(
-    tx: any,
+    tx: Prisma.TransactionClient,
     token: string,
     ledger: number,
   ): Promise<void> {


### PR DESCRIPTION
Closes #815 #816 #817 #818

## Summary

This PR bundles four backend improvements across badge-awarder and event-indexer:

1. **#815** — badge-awarder: Add default case with warning log
   - Switch statement now alerts when unknown badge criteria appears
   - Prevents silent badge non-awards when new criteria added to database

2. **#816** — event-indexer: Add TAKE limit to resolveOrphans
   - Limit to 100 orphans per tick, preventing full table scans
   - O(n) scan every 10s on large orphan sets → O(1) batched processing

3. **#817** — event-indexer: Document timestamp-based insert detection limitation
   - Added clarifying comment on createdAt == updatedAt heuristic
   - Notes the ms-resolution edge case and TODO for xmax-based detection

4. **#818** — event-indexer: Fix Prisma transaction type safety
   - Replace 'tx: any' with 'tx: Prisma.TransactionClient'
   - Restores compile-time type checking, catches bugs before runtime

## Test Plan

- [x] TypeScript compiles without errors
- [x] All existing tests pass
- [x] Badge award logic unchanged (default case only logs + breaks)
- [x] Orphan resolution still processes all orphans (batched over ticks)
- [x] Cursor writes within transaction still work correctly

## Acceptance Criteria

- [x] Closes #815 — badge-awarder has default case with warning log
- [x] Closes #816 — resolveOrphans uses take: 100 limit
- [x] Closes #817 — Timestamp limitation documented with TODO
- [x] Closes #818 — writeCursorWithinTx uses Prisma.TransactionClient type