### PR TITLE
fix: resolve 4 backend bugs — Prisma type safety, scheduler idempotency, admin error codes, webhook retry

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3729,7 +3729,10 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
   v1Router.post("/profiles/:username/badges", requireAuth, async (req, res) => {
     // Admin-only: only the configured admin wallet may assign badges
-    if (!req.auth || !ADMIN_WALLET || req.auth.walletAddress !== ADMIN_WALLET) {
+    if (!ADMIN_WALLET) {
+      return sendError(res, 503, "Admin endpoint not configured");
+    }
+    if (!req.auth || req.auth.walletAddress !== ADMIN_WALLET) {
       return sendError(res, 403, "Forbidden: Admin access required");
     }
 
@@ -3781,7 +3784,10 @@ All errors return JSON with an \`error\` field and optional \`code\`:
    *         description: Internal server error
    */
   v1Router.post("/admin/webhooks/requeue", requireAuth, async (req, res) => {
-    if (!req.auth || !ADMIN_WALLET || req.auth.walletAddress !== ADMIN_WALLET) {
+    if (!ADMIN_WALLET) {
+      return sendError(res, 503, "Admin endpoint not configured");
+    }
+    if (!req.auth || req.auth.walletAddress !== ADMIN_WALLET) {
       return sendError(res, 403, "Forbidden: Admin access required");
     }
 
@@ -4492,7 +4498,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
             AND "status" != 'failed'
             AND "createdAt" >= ${from}
             AND "createdAt" <= ${to}
-            ${assetCode ? (Prisma as any).sql`AND "assetCode" = ${assetCode}` : (Prisma as any).empty}
+            ${assetCode ? Prisma.sql`AND "assetCode" = ${assetCode}` : Prisma.empty}
           GROUP BY DATE_TRUNC('month', "createdAt")
           ORDER BY date ASC
         `;
@@ -4507,7 +4513,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
             AND "status" != 'failed'
             AND "createdAt" >= ${from}
             AND "createdAt" <= ${to}
-            ${assetCode ? (Prisma as any).sql`AND "assetCode" = ${assetCode}` : (Prisma as any).empty}
+            ${assetCode ? Prisma.sql`AND "assetCode" = ${assetCode}` : Prisma.empty}
           GROUP BY DATE_TRUNC('week', "createdAt")
           ORDER BY date ASC
         `;
@@ -4522,7 +4528,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
             AND "status" != 'failed'
             AND "createdAt" >= ${from}
             AND "createdAt" <= ${to}
-            ${assetCode ? (Prisma as any).sql`AND "assetCode" = ${assetCode}` : (Prisma as any).empty}
+            ${assetCode ? Prisma.sql`AND "assetCode" = ${assetCode}` : Prisma.empty}
           GROUP BY DATE_TRUNC('day', "createdAt")
           ORDER BY date ASC
         `;

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -59,20 +59,23 @@ export async function processDueRecurringSupports(prismaClient = prisma, now = n
           ? new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
           : addMonths(now, 1);
 
-      await prismaClient.$transaction(async (tx: any) => {
-        // Create the pending RecurringSupportExecution
-        await tx.recurringSupportExecution.create({
-          data: {
-            recurringSupportId: support.id,
-            status: "pending",
-          },
-        });
+      // Atomic claim: only one scheduler instance wins the row
+      const claimed = await prismaClient.$executeRaw`
+        UPDATE "RecurringSupport"
+        SET "nextRunAt" = ${nextRunAt}
+        WHERE id = ${support.id} AND "nextRunAt" <= ${now}
+      `;
 
-        // Update the RecurringSupport
-        await tx.recurringSupport.update({
-          where: { id: support.id },
-          data: { nextRunAt },
-        });
+      if (claimed === 0) {
+        logger.info({ dripId: support.id }, "Recurring support already claimed by another process");
+        continue;
+      }
+
+      await prismaClient.recurringSupportExecution.create({
+        data: {
+          recurringSupportId: support.id,
+          status: "pending",
+        },
       });
 
       logger.info({

--- a/backend/src/services/webhook.ts
+++ b/backend/src/services/webhook.ts
@@ -79,8 +79,6 @@ export async function deliverWebhook(
       willRetry:
         response.status >= 500 ||
         response.status === 429 ||
-        response.status === 401 ||
-        response.status === 403 ||
         response.status === 408,
     };
   } catch (error: unknown) {


### PR DESCRIPTION
Closes #807 , Closes #808, Closes #809, Closes #814

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional or behavioral changes)
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Build / CI configuration change
- [ ] Dependency update
- [ ] Other: <!-- describe -->

---

## Summary

This PR fixes four backend bugs:
1. **#807**: Removes `Prisma as any` casts in timeseries analytics queries, restoring compile-time type safety for `Prisma.sql` and `Prisma.empty`.
2. **#808**: Adds an atomic `UPDATE ... WHERE` idempotency guard to the drip scheduler, preventing duplicate `RecurringSupportExecution` rows when multiple scheduler instances run concurrently.
3. **#809**: Returns HTTP 503 when the admin wallet is not configured (misconfiguration), separate from 403 for unauthorized access, so operators can distinguish the two cases.
4. **#814**: Removes HTTP 401 and 403 from webhook retry conditions since permanent auth errors won't resolve on retry.

## Motivation / Context

These are bug fixes for issues assigned to me. Each addresses a specific reliability or correctness problem in the backend:
- `Prisma as any` bypasses type checking and will silently fail if Prisma changes exports
- Concurrent scheduler instances can create duplicate executions, billing supporters twice
- Identical 403 responses for misconfiguration vs unauthorized access make debugging impossible
- Retrying permanent 401/403 errors wastes delivery slots for nearly 2 minutes

Closes #807, Closes #808, Closes #809, Closes #814