### PR TITLE
Fix/796 797 798 799 backend bugs

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -284,6 +284,16 @@ function createRateLimiters() {
     message: { error: "Too many requests, please try again later." },
   });
 
+  // RSS feed limiter — 10 requests per minute per IP (#799)
+  const feedLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => process.env.NODE_ENV === "test",
+    message: { error: "Too many requests, please try again later." },
+  });
+
   return {
     globalLimiter,
     writeLimiter,
@@ -292,6 +302,7 @@ function createRateLimiters() {
     viewCountLimiter,
     authLimiter,
     federationLimiter,
+    feedLimiter,
   };
 }
 
@@ -387,6 +398,7 @@ export function createApp(customLogger?: Logger) {
     viewCountLimiter,
     authLimiter,
     federationLimiter,
+    feedLimiter,
   } = createRateLimiters();
 
   const swaggerSpec = swaggerJsdoc({
@@ -3356,7 +3368,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
   // ── Profile RSS feed (#478) ───────────────────────────────────────────
 
-  v1Router.get("/profiles/:username/feed.xml", async (req, res) => {
+  v1Router.get("/profiles/:username/feed.xml", feedLimiter, async (req, res) => {
     const { username } = req.params;
 
     const profile = await prisma.profile.findUnique({
@@ -3973,9 +3985,21 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return sendError(res, 400, "Invalid request body");
       }
 
+      if (milestone.status === "reached" && parsed.data.targetAmount !== undefined) {
+        return sendError(res, 400, "Cannot change targetAmount of a reached milestone");
+      }
+
+      const data: typeof parsed.data & { status?: string } = { ...parsed.data };
+      if (
+        parsed.data.targetAmount !== undefined &&
+        Number(milestone.currentAmount) >= Number(parsed.data.targetAmount)
+      ) {
+        data.status = "reached";
+      }
+
       const updated = await prisma.milestone.update({
         where: { id: milestoneId },
-        data: parsed.data,
+        data,
       });
 
       res.json(updated);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3870,7 +3870,10 @@ All errors return JSON with an \`error\` field and optional \`code\`:
   const createMilestoneSchema = z.object({
     title: z.string().min(1).max(100),
     description: z.string().max(500).optional().nullable(),
-    targetAmount: z.string().min(1),
+    targetAmount: z
+      .string()
+      .regex(/^\d+(\.\d{1,7})?$/, "Must be a positive decimal with up to 7 places")
+      .refine((v) => parseFloat(v) > 0, "Must be greater than zero"),
     assetCode: z.string().default("XLM"),
   });
 

--- a/backend/src/services/drip-scheduler.ts
+++ b/backend/src/services/drip-scheduler.ts
@@ -56,8 +56,8 @@ export async function processDueRecurringSupports(prismaClient = prisma, now = n
       // Calculate nextRunAt based on frequency
       const nextRunAt =
         support.frequency === "weekly"
-          ? new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-          : addMonths(now, 1);
+          ? new Date(support.nextRunAt.getTime() + 7 * 24 * 60 * 60 * 1000)
+          : addMonths(support.nextRunAt, 1);
 
       // Atomic claim: only one scheduler instance wins the row
       const claimed = await prismaClient.$executeRaw`


### PR DESCRIPTION
## Summary
- Validate milestone `targetAmount` as a positive decimal (up to 7 places) on both create and update, instead of letting Prisma throw an unhandled 500 on non-numeric input
- Fix drip scheduler `nextRunAt` calculation to base off the original `support.nextRunAt` instead of the late-processing time, preventing schedule drift
- Add a dedicated rate limiter (10 req/min per IP) to the RSS feed endpoint (`GET /profiles/:username/feed.xml`)
- Guard milestone updates: reject `targetAmount` changes on already-reached milestones, and auto-mark a milestone as `reached` if a lowered `targetAmount` drops to/below `currentAmount`

## Test plan
- [ ] PATCH a reached milestone with a `targetAmount` change → expect 400
- [ ] PATCH an active milestone lowering `targetAmount` below `currentAmount` → status flips to `reached`
- [ ] POST/PATCH milestone with `targetAmount: 'abc'`, `'0'`, `'-50'` → expect 400, not 500
- [ ] Hit `feed.xml` >10 times/min from one IP → expect 429
- [ ] Verify drip scheduler run processed late still lands on the original weekly/monthly cadence

Closes #796
Closes #797
Closes #798
Closes #799