### PR TITLE
fix: add GitHub fetch timeout and escape user input in HTML emails

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,7 +27,7 @@ import {
 } from "./auth.js";
 import multer from "multer";
 import { createClient } from "@supabase/supabase-js";
-import { sendSupportReceivedEmail } from "./services/email.js";
+import { sendSupportReceivedEmail, escapeHtml } from "./services/email.js";
 import { sendVerificationEmail } from "./emails/verify-email.js";
 import {
   getCachedLeaderboard,
@@ -4107,8 +4107,8 @@ All errors return JSON with an \`error\` field and optional \`code\`:
             subject: `[NovaSupport] Profile @${username} has ${reportCount} report(s)`,
             html: `
               <p>Profile <strong>@${username}</strong> has accumulated <strong>${reportCount}</strong> report(s).</p>
-              <p>Latest report reason: <strong>${parsed.data.reason}</strong></p>
-              ${parsed.data.details ? `<p>Details: ${parsed.data.details}</p>` : ""}
+              <p>Latest report reason: <strong>${escapeHtml(parsed.data.reason)}</strong></p>
+              ${parsed.data.details ? `<p>Details: ${escapeHtml(parsed.data.details)}</p>` : ""}
               <p>Please review this profile in the admin panel.</p>
             `,
           });

--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -1,5 +1,13 @@
 import { sendEmail } from "../mailer.js";
 
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
 interface SendSupportReceivedEmailParams {
   to: string;
   fromAddress: string;
@@ -28,7 +36,7 @@ export async function sendSupportReceivedEmail({
   const html = `
     <h2>You've received support!</h2>
     <p>A supporter (${truncatedAddress}) has sent you <strong>${amount} ${assetCode}</strong>.</p>
-    ${message ? `<p><strong>Message:</strong> "${message}"</p>` : ""}
+    ${message ? `<p><strong>Message:</strong> "${escapeHtml(message)}"</p>` : ""}
     <p><a href="${stellarExpertLink}">View transaction on Stellar Expert</a></p>
     <br/>
     <p>Thanks,<br/>The NovaSupport Team</p>

--- a/backend/src/services/profile-importer.ts
+++ b/backend/src/services/profile-importer.ts
@@ -70,7 +70,7 @@ export async function fetchGitHubProfile(
   try {
     response = await fetch(
       `${GITHUB_API_BASE}/users/${encodeURIComponent(username)}`,
-      { headers },
+      { headers, signal: AbortSignal.timeout(10_000) },
     );
   } catch (err) {
     throw new GitHubFetchError(0, err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
- profile-importer.ts: add 10s AbortSignal timeout to GitHub API fetch so a slow/unresponsive GitHub API can't hang the request indefinitely
- email.ts: HTML-escape the supporter message before interpolating it into the support-received email body, preventing HTML injection
- app.ts: apply the same escaping to the admin alert email's reason and details fields

Closes #883
Closes #882
Closes #879 
Closes #880 
