### PR TITLE
fix: stop embed page rendering its own html/head/body (closes #827)

### DIFF
--- a/frontend/public/embed.css
+++ b/frontend/public/embed.css
@@ -11,6 +11,11 @@ html,
 body {
   margin: 0;
   padding: 0;
+  /* The embed route is meant to render transparently inside a host page's
+     iframe. It still inherits the root layout's <html>/<body>, whose
+     globals.css sets an opaque gradient background — override it here so
+     the widget doesn't show a solid background box in embeds. */
+  background: transparent !important;
 }
 
 .w-full {

--- a/frontend/src/app/embed/[username]/page.tsx
+++ b/frontend/src/app/embed/[username]/page.tsx
@@ -62,6 +62,7 @@ export async function generateMetadata({ params }: { params: { username: string 
   return {
     title: `Support ${profile.displayName} — NovaSupport`,
     robots: { index: false, follow: false },
+    viewport: "width=device-width, initial-scale=1",
   };
 }
 
@@ -92,34 +93,27 @@ export default async function EmbedPage({ params, searchParams }: PageProps) {
   }));
 
   return (
-    <html lang="en">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="robots" content="noindex" />
-        <link rel="stylesheet" href="/embed.css" />
-      </head>
-      <body
-        style={{
-          margin: 0,
-          padding: 8,
-          background: "transparent",
-          fontFamily: "system-ui, -apple-system, sans-serif",
-        }}
-      >
-        <EmbedWidget
-          username={profile.username}
-          displayName={profile.displayName}
-          bio={profile.bio}
-          avatarUrl={profile.avatarUrl}
-          acceptedAssets={profile.acceptedAssets}
-          stats={stats}
-          recentSupporters={recentSupporters}
-          theme={theme}
-          size={size}
-          profileUrl={profileUrl}
-        />
-      </body>
-    </html>
+    <div
+      style={{
+        margin: 0,
+        padding: 8,
+        background: "transparent",
+        fontFamily: "system-ui, -apple-system, sans-serif",
+      }}
+    >
+      <link rel="stylesheet" href="/embed.css" />
+      <EmbedWidget
+        username={profile.username}
+        displayName={profile.displayName}
+        bio={profile.bio}
+        avatarUrl={profile.avatarUrl}
+        acceptedAssets={profile.acceptedAssets}
+        stats={stats}
+        recentSupporters={recentSupporters}
+        theme={theme}
+        size={size}
+        profileUrl={profileUrl}
+      />
+    </div>
   );
 }

--- a/frontend/src/app/embed/layout.tsx
+++ b/frontend/src/app/embed/layout.tsx
@@ -1,0 +1,7 @@
+// The embed route renders a minimal, iframe-friendly widget and must not
+// inherit the app's root <html>/<body> chrome (theme script, gradient
+// background, Providers). This layout opts the /embed/* subtree out of the
+// nesting Next.js would otherwise apply from app/layout.tsx.
+export default function EmbedLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
Split out of #842 per request. Closes #827.