### PR TITLE
fix: resolve config drift and RecipientTotal contract issues

### DIFF
--- a/contract/contracts/support_page/src/lib.rs
+++ b/contract/contracts/support_page/src/lib.rs
@@ -322,6 +322,16 @@ pub fn unpause(e: Env) -> Result<(), Error> {
         st.set(&key, &(balance - amount));
         st.extend_ttl(&key, LEDGERS_THRESHOLD, LEDGERS_TO_LIVE);
 
+        let recipient_total_key = DataKey::RecipientTotal(recipient.clone());
+        let recipient_total: i128 = st.get(&recipient_total_key).unwrap_or(0);
+        let new_recipient_total = if recipient_total >= amount {
+            recipient_total - amount
+        } else {
+            0
+        };
+        st.set(&recipient_total_key, &new_recipient_total);
+        st.extend_ttl(&recipient_total_key, LEDGERS_THRESHOLD, LEDGERS_TO_LIVE);
+
         // Emit a withdraw event
         e.events()
             .publish((symbol_short!("withdraw"), caller, asset), amount);
@@ -340,6 +350,13 @@ pub fn unpause(e: Env) -> Result<(), Error> {
         e.storage()
             .persistent()
             .get(&DataKey::RecipientCount(r))
+            .unwrap_or(0)
+    }
+
+    pub fn get_recipient_total(e: Env, r: Address) -> i128 {
+        e.storage()
+            .persistent()
+            .get(&DataKey::RecipientTotal(r))
             .unwrap_or(0)
     }
 
@@ -395,6 +412,7 @@ mod test {
             client.get_total_by_asset(&recipient, &asset),
             8_000_000_i128
         );
+        assert_eq!(client.get_recipient_total(&recipient), 8_000_000_i128);
     }
 
     #[test]
@@ -479,11 +497,13 @@ mod test {
         );
 
         assert_eq!(client.get_total_by_asset(&recipient, &asset), 10_000_i128);
+        assert_eq!(client.get_recipient_total(&recipient), 10_000_i128);
 
         // Withdraw half
         client.withdraw(&recipient, &recipient, &asset, &5_000_i128);
 
         assert_eq!(client.get_total_by_asset(&recipient, &asset), 5_000_i128);
+        assert_eq!(client.get_recipient_total(&recipient), 5_000_i128);
 
         // Verify token balance of recipient
         let token_client = soroban_sdk::token::Client::new(&e, &asset);

--- a/frontend/src/app/recurring/page.tsx
+++ b/frontend/src/app/recurring/page.tsx
@@ -7,8 +7,7 @@ import { AppShell } from "@/components/app-shell";
 import { Toast } from "@/components/toast";
 import { EmptyState } from "@/components/empty-state";
 import { apiFetch } from "@/lib/api-client";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+import { API_BASE_URL } from "@/lib/config";
 
 interface RecurringSupport {
   id: string;

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -6,8 +6,7 @@ import { AppShell } from "@/components/app-shell";
 import { Toast } from "@/components/toast";
 import { NotificationPreferences } from "@/components/notification-preferences";
 import { apiFetch } from "@/lib/api-client";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
+import { API_BASE_URL } from "@/lib/config";
 
 export default function SettingsPage() {
   const router = useRouter();

--- a/frontend/src/components/onboarding-checklist.tsx
+++ b/frontend/src/components/onboarding-checklist.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Check } from "lucide-react";
 import { apiFetch } from "@/lib/api-client";
+import { API_BASE_URL } from "@/lib/config";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
 const DISMISSED_KEY_PREFIX = "onboardingChecklistDismissed:";
 
 type ChecklistItem = {


### PR DESCRIPTION
## Summary
- Import `API_BASE_URL` from `@/lib/config` in `settings/page.tsx`, `recurring/page.tsx`, and `onboarding-checklist.tsx` instead of hardcoding local fallbacks (closes #855, #856, #857)
- Add public `get_recipient_total` getter on the support page contract
- Decrement `RecipientTotal` in `withdraw()` so aggregate totals stay accurate after withdrawals (closes #853)

## Test plan
- [ ] Confirm the three frontend files import `API_BASE_URL` from `@/lib/config` and no longer define a local constant
- [ ] Confirm unset `NEXT_PUBLIC_API_BASE_URL` uses the shared `localhost:3001` default from config
- [ ] Run contract tests covering support + withdraw and assert `get_recipient_total` matches remaining balance
- [ ] Smoke-check settings, recurring, and onboarding checklist pages still load profile/API data

Closes #853
Closes #855
Closes #856
Closes #857