### PR TITLE
fix(#875): verify supporters route registration and improve error log…

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4241,7 +4241,8 @@ All errors return JSON with an \`error\` field and optional \`code\`:
           hasMore: offset + limit < totalCount,
         },
       });
-    } catch {
+    } catch (err) {
+      req.log.error({ err }, "failed to fetch supporter history");
       return sendError(res, 500, "Internal server error");
     }
   });


### PR DESCRIPTION
The GET /supporters/:address route registration (v1Router.get) was previously missing, leaving the handler body orphaned and breaking the TypeScript build with TS1128 errors at lines 4211 and 4753.

The route opening line has been confirmed present and the build-breaking orphan is resolved. Additionally, improve the bare catch block in the supporters handler to log errors via req.log.error for consistency with all other route handlers in the file, making failures diagnosable in production logs.
Closes #875 