### PR TITLE
fix(#876): rename totalByAsset to assetTotals in profiles/stats endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1492,7 +1492,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
 
       const totalTransactions = assetGroups.reduce((acc: number, g: any) => acc + g._count, 0);
 
-      const totalByAsset = assetGroups.map((g: any) => ({
+      const assetTotals = assetGroups.map((g: any) => ({
         assetCode: g.assetCode,
         assetIssuer: g.assetIssuer,
         total: g._sum.amount ? g._sum.amount.toFixed(7) : "0.0000000",
@@ -1501,7 +1501,7 @@ All errors return JSON with an \`error\` field and optional \`code\`:
       res.json({
         totalTransactions,
         uniqueSupporters: uniqueSupportersList.length,
-        totalByAsset,
+        assetTotals,
         firstSupportedAt: aggregates._min.createdAt ? aggregates._min.createdAt.toISOString() : null,
         lastSupportedAt: aggregates._max.createdAt ? aggregates._max.createdAt.toISOString() : null,
       });

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -250,7 +250,7 @@ async function main() {
       assert.ok(body.lastSupportedAt);
 
       // Sort to ensure deterministic deepEqual
-      const sortedTotals = body.totalByAsset.sort((a: any, b: any) => a.assetCode.localeCompare(b.assetCode));
+      const sortedTotals = body.assetTotals.sort((a: any, b: any) => a.assetCode.localeCompare(b.assetCode));
       assert.deepEqual(sortedTotals, [
         { assetCode: "USDC", assetIssuer: null, total: "2.2500000" },
         { assetCode: "XLM", assetIssuer: null, total: "114.5000000" },


### PR DESCRIPTION
The GET /api/v1/profiles/:username/stats response was returning totalByAsset but all frontend consumers (profile page, embed page, embed-widget component, profile-card component) expected assetTotals. This caused the Total Raised stat to always display 0 since stats?.assetTotals was always undefined.

Fix: rename the local variable and response field from totalByAsset to assetTotals in the profiles/:username/stats handler. Update the corresponding assertion in index.test.ts from body.totalByAsset to body.assetTotals to keep the test suite consistent.

The supporters/:address endpoint retains its own totalByAsset field which is consumed correctly by the supporters page.
Closes #876 