### PR TITLE
fix(#877): pass actual recent transactions in analytics endpoint

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3603,12 +3603,29 @@ All errors return JSON with an \`error\` field and optional \`code\`:
         return res.send(createAnalyticsCsv(transactions));
       }
 
-      const analytics = await getAnalytics(profile.id, start, end, "json");
+      const [analytics, recentTransactions] = await Promise.all([
+        getAnalytics(profile.id, start, end, "json"),
+        prisma.supportTransaction.findMany({
+          where: { profileId: profile.id },
+          orderBy: { createdAt: "desc" },
+          take: 10,
+          select: {
+            id: true,
+            txHash: true,
+            amount: true,
+            assetCode: true,
+            supporterAddress: true,
+            createdAt: true,
+            status: true,
+            message: true,
+          },
+        }),
+      ]);
 
       res.json({
         profile: { username: profile.username, displayName: profile.displayName },
         ...analytics,
-        recentTransactions: analytics.dailyContributions, // For backward compatibility or adjustment
+        recentTransactions,
       });
     } catch (err) {
       req.log.error({ err }, "failed to fetch analytics");


### PR DESCRIPTION
The GET /api/v1/analytics/:username endpoint was incorrectly aliasing analytics.dailyContributions (time-series aggregates with date/amount fields) as recentTransactions. The dashboard Recent Activity tab expects real transaction records with id, supporterAddress, assetCode, amount, and createdAt fields.

Fix: fetch the 10 most recent SupportTransaction rows via prisma.supportTransaction.findMany concurrently with getAnalytics, and include them under recentTransactions in the response. Remove the incorrect dailyContributions alias.
Closes #877 

